### PR TITLE
Bug Fix: Clarify CollabArtistLink and displayAlbum

### DIFF
--- a/frontend/components/songs/collab_card.jsx
+++ b/frontend/components/songs/collab_card.jsx
@@ -29,10 +29,10 @@ const CollabSongCard = ({
     }
 
     return (
-        <div className="card album-card"
-            onClick={handleClick}
-        >
-            <div className="album-card-art">
+        <div className="card album-card">
+            <div className="album-card-art"
+                onClick={handleClick}
+            >
                 <img src={albumImageUrl} alt="" />
             </div>
             <div className="card-title">


### PR DESCRIPTION
onClick for displayAlbum was overriding clicking through ArtistLink to the collab artists on a Collabcard

~ Move onClick displayAlbum to album art rather than entire Collab Card div