### PR TITLE
Bug Fix: 'Untitled Playlist #0'

### DIFF
--- a/frontend/components/sidebar/sidebar.jsx
+++ b/frontend/components/sidebar/sidebar.jsx
@@ -33,7 +33,7 @@ const Sidebar = (props) => {
     const handleSubmitCreate = (e) => {
         e.preventDefault();
 
-        const number = playlists.length;
+        const number = playlists.length + 1;
 
         const defaultNewPlaylist = { 
             title: `Untitled Playlist #${number}`,


### PR DESCRIPTION
Addresses a bug discovered where the first playlist, when created by clicking "Create Playlist" by a user who has no playlists, is titled with "#0".

![image](https://github.com/imartinez921/versify_full-stack/assets/102888592/249323fc-c0ef-4aa5-a75b-549b639635f6)

After fix:
![image](https://github.com/imartinez921/versify_full-stack/assets/102888592/f6a30e60-01dc-4826-b1dd-577da2469848)