### PR TITLE
[songCardDropdown] Implement EventListeners and freeze scrolling

### DIFF
--- a/app/assets/stylesheets/14-song-index.scss
+++ b/app/assets/stylesheets/14-song-index.scss
@@ -87,3 +87,8 @@
     text-align: center;
     margin-right: 25px;
 }
+
+.song-card-menu-dots {
+    position: relative;
+    z-index: 3;
+}

--- a/app/assets/stylesheets/15-song-card-dropdown.scss
+++ b/app/assets/stylesheets/15-song-card-dropdown.scss
@@ -1,3 +1,13 @@
+div.dropdown-background {
+    position: fixed;
+    top: 0px;
+    left: 0px;
+    background-color: transparent;
+    height: 100vh;
+    width: 100vw;
+    z-index: 2;
+}
+
 .song-card-dropdown {
     align-items: flex-start;
     font-size: 15px;

--- a/frontend/components/nav_bar/dropdown_background.jsx
+++ b/frontend/components/nav_bar/dropdown_background.jsx
@@ -1,0 +1,24 @@
+import React, { useEffect, useRef } from "react";
+    
+
+const DropdownBackground = ({ updateDropdownState }) => {
+    const backgroundRef = useRef();
+
+    useEffect(() => {
+        const handler = (event) => {
+            if (backgroundRef.current.contains(event.target)) {
+                updateDropdownState({ isOpen: false });
+            }
+        };
+        document.addEventListener("mousedown", handler);
+        document.addEventListener("touchstart", handler);
+        return () => {
+            document.removeEventListener("mousedown", handler);
+            document.removeEventListener("touchstart", handler);
+        };
+    });
+
+    return <div className="dropdown-background" ref={backgroundRef}></div>;
+};
+
+export default DropdownBackground;

--- a/frontend/components/playlists/playlist_show.jsx
+++ b/frontend/components/playlists/playlist_show.jsx
@@ -28,7 +28,9 @@ const PlaylistShow = ({
     }, [urlParams]);
 
     const playlistShow = title ? (
-        <div className="playlist-show">
+        <div 
+            id="playlist-show"
+            className="playlist-show">
             <div className="playlist-header">
                 <PlaylistHeader
                     title={title}

--- a/frontend/components/songs/song_index.jsx
+++ b/frontend/components/songs/song_index.jsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { useState, useEffect, useRef } from "react";
+import { freezeScroll, permitScroll } from "../../modules/dropdown_functions";
 import SongCard from "./song_card";
 import SongCardDropdownContainer from "./song_card_dropdown_container";
 import DropdownBackground from "../nav_bar/dropdown_background";
@@ -105,6 +106,12 @@ const SongIndex = ({
             }
         </div>    
     )
+
+    if (songCardDropdownState.isOpen) {
+        freezeScroll('playlist-show');
+    } else {
+        permitScroll('playlist-show');
+    }
 
     const depthLevel = 0;
     return (

--- a/frontend/components/songs/song_index.jsx
+++ b/frontend/components/songs/song_index.jsx
@@ -2,6 +2,7 @@ import React from "react";
 import { useState, useEffect, useRef } from "react";
 import SongCard from "./song_card";
 import SongCardDropdownContainer from "./song_card_dropdown_container";
+import DropdownBackground from "../nav_bar/dropdown_background";
 
 
 const SongIndex = ({
@@ -106,22 +107,30 @@ const SongIndex = ({
     )
 
     const depthLevel = 0;
-    return <>
-        {songs.length > 0 ? songIndex : emptyPlaylist}
-        {songCardDropdownState.isOpen && <SongCardDropdownContainer 
-                currentUser={currentUser}
-                history={history}
-                selectedSong={selectedSong}
-                songCardDropdownState={songCardDropdownState}
-                updateSongCardDropdownState={updateSongCardDropdownState}
-                updateDropdownPosition={updateDropdownPosition}
-                items={songCardDropdownItems}
-                depthLevel={depthLevel}
-                dropdownPosition={dropdownPosition}
-                dropdownMenuPointer={dropdownMenuPointer}
-            />
-        }
-    </>
+    return (
+        <>
+            {songs.length > 0 ? songIndex : emptyPlaylist}
+            {songCardDropdownState.isOpen && (
+                <DropdownBackground
+                    updateDropdownState={updateSongCardDropdownState}
+                />
+            )}
+            {songCardDropdownState.isOpen && (
+                <SongCardDropdownContainer
+                    currentUser={currentUser}
+                    history={history}
+                    selectedSong={selectedSong}
+                    songCardDropdownState={songCardDropdownState}
+                    updateSongCardDropdownState={updateSongCardDropdownState}
+                    updateDropdownPosition={updateDropdownPosition}
+                    items={songCardDropdownItems}
+                    depthLevel={depthLevel}
+                    dropdownPosition={dropdownPosition}
+                    dropdownMenuPointer={dropdownMenuPointer}
+                />
+            )}
+        </>
+    );
 }
 
 export default SongIndex;

--- a/frontend/modules/dropdown_functions.js
+++ b/frontend/modules/dropdown_functions.js
@@ -1,13 +1,27 @@
+export const freezeScroll = (parentDivIdStr) => {
+    const parentDiv = document.getElementById(parentDivIdStr);
+    if (parentDiv) {
+        parentDiv.style.overflowY = 'hidden';
+    }
+};
+export const permitScroll = (parentDivIdStr) => {
+    const parentDiv = document.getElementById(parentDivIdStr);
+    if (parentDiv) {
+        parentDiv.style.overflowY = 'auto';
+    }
+};
+
 export const isInViewport = (ele) => {
     const rect = ele.getBoundingClientRect();
     return (
         rect.top >= 0 &&
         rect.left >= 0 &&
-        rect.bottom <= (window.innerHeight || document.documentElement.clientHeight) &&
-        rect.right <= (window.innerWidth || document.documentElement.clientWidth)
-
+        rect.bottom <=
+            (window.innerHeight || document.documentElement.clientHeight) &&
+        rect.right <=
+            (window.innerWidth || document.documentElement.clientWidth)
     );
-}
+};
 // Explain isInViewport line by line
 export const moveWithinViewport = (left, top, right, bottom) => {
     let nextLeft, nextTop, nextRight, nextBottom;
@@ -16,4 +30,4 @@ export const moveWithinViewport = (left, top, right, bottom) => {
     if (right > window.innerWidth) nextRight = window.innerWidth - right;
     if (bottom > window.innerHeight) nextBottom = window.innerHeight - bottom;
     return { nextLeft, nextTop, nextRight, nextBottom };
-}
+};


### PR DESCRIPTION
1) Addresses #57 where initial dropdown of recursive SongCardDropdownContainer would not close when user clicked outside
2) Addresses bug where PlaylistShow would still scroll with dropdown open
   * Implements modal-like solution through a transparent, reusable DropdownBackground component that takes in any corresponding dropdown state updater function and changes it to false upon onClick
   * Added z-index to "menu-dots" div to allow toggleSongCardDropdown to trigger when dropdown is open
   * Implements two new functions 

_Bug:_

https://github.com/imartinez921/versify_full-stack/assets/102888592/32803bd0-641b-4a4c-985c-2b327bb05d12



After fix:
