### PR TITLE
Use dropdownRef to close initial dropdown div

### DIFF
--- a/frontend/components/songs/song_card_dropdown.jsx
+++ b/frontend/components/songs/song_card_dropdown.jsx
@@ -9,6 +9,7 @@ const SongCardDropdown = ({
     currentUser,
     history,
     selectedSong,
+    songCardDropdownState,
     updateSongCardDropdownState,
     items,
     depthLevel,
@@ -26,7 +27,7 @@ const SongCardDropdown = ({
     useEffect(() => {
         const handler = (event) => {
             if (
-                submenuState.isOpen &&
+                songCardDropdownState.isOpen &&
                 dropdownRef.current &&
                 !dropdownRef.current.contains(event.target)
             ) {
@@ -41,7 +42,7 @@ const SongCardDropdown = ({
             document.removeEventListener("mousedown", handler);
             document.removeEventListener("touchstart", handler);
         };
-    }, [submenuState]);
+    }, [songCardDropdownState]);
 
     const toggleSubmenuAndPlaceDropdown = (e) => {
         e.preventDefault();
@@ -61,7 +62,7 @@ const SongCardDropdown = ({
         <div
             className="song-card-dropdown dropdown-item"
             data-dropdown
-            ref={dropdownRef}
+            ref={dropdownRef} // Note that I didn't change the position of the ref in both commits
             style={{
                 left: `${dropdownPosition.left}px`,
                 top: `${dropdownPosition.top}px`,
@@ -87,6 +88,7 @@ const SongCardDropdown = ({
                             history={history}
                             currentUser={currentUser}
                             selectedSong={selectedSong}
+                            songCardDropdownState={songCardDropdownState}
                             submenus={item.submenu}
                             submenuState={submenuState}
                             depthLevel={depthLevel}

--- a/frontend/components/songs/song_card_dropdown_container.jsx
+++ b/frontend/components/songs/song_card_dropdown_container.jsx
@@ -25,6 +25,7 @@ const mapStateToProps = (state, ownProps) => {
         currentUser: ownProps.currentUser,
         history: ownProps.history,
         selectedSong: ownProps.selectedSong,
+        songCardDropdownState: ownProps.songCardDropdownState,
         updateSongCardDropdownState: ownProps.updateSongCardDropdownState,
         updateDropdownPosition: ownProps.updateDropdownPosition,
         items: ownProps.items, // already contains current playlists from SongIndex

--- a/frontend/components/songs/song_card_submenu.jsx
+++ b/frontend/components/songs/song_card_submenu.jsx
@@ -5,6 +5,7 @@ const SongCardSubmenu = ({
     history,
     currentUser,
     selectedSong,
+    songCardDropdownState,
     submenus,
     submenuState,
     depthLevel,
@@ -28,6 +29,7 @@ const SongCardSubmenu = ({
                         history={history}
                         currentUser={currentUser}
                         selectedSong={selectedSong}
+                        songCardDropdownState={songCardDropdownState}
                         items={submenu}
                         depthLevel={depthLevel}
                         dropdownPosition={dropdownPosition}


### PR DESCRIPTION
Using `dropdownRef` with the event listeners dependent on `songCardDropdownState` doesn't allow the user open the child submenu anymore. Might need to configure more If statements in the eventListener somehow using subMenuState but not sure what yet. Open to ideas otherwise will abandon this approach. Will revisit later.

Main branch's functioning can be seen as it is currently live on Heroku(https://versify-idm-402fcc1678c6.herokuapp.com/); detailed in **Next Steps** at the bottom of #57 

https://github.com/imartinez921/versify_full-stack/assets/102888592/43d4fa64-f1ee-4b01-bc5e-f051848017cc