### PR TITLE
Use refs to prevent scrolling when SongCardDropdown is open

### DIFF
--- a/frontend/components/albums/album_show.jsx
+++ b/frontend/components/albums/album_show.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from "react";
+import React, { useEffect, useRef } from "react";
 
 import AlbumHeader from "./album_header";
 import AlbumNav from "./album_nav";
@@ -25,8 +25,10 @@ const AlbumShow = ({
         return () => clearCurrent();
     }, [urlParams]); // Will run whenever urlParams.id changes, otherwise ArtistShow doesn't re-render
 
+    const albumShowRef = useRef();
+
     const albumShow = (
-        <div className="album-show">
+        <div className="album-show" ref={albumShowRef}>
             <div className="album-header">
                 <AlbumHeader
                     album={currentAlbum}
@@ -42,6 +44,7 @@ const AlbumShow = ({
                 history={history}
                 source={source}
                 songCardDropdownItems={songCardDropdownItems}
+                currentViewRef={albumShowRef}
             />
         </div>
     )

--- a/frontend/components/playlists/playlist_show.jsx
+++ b/frontend/components/playlists/playlist_show.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from "react";
+import React, { useEffect, useRef } from "react";
 import PlaylistHeader from "./playlist_header";
 import PlaylistNav from "./playlist_nav";
 import SongIndex from "../songs/song_index";
@@ -27,8 +27,10 @@ const PlaylistShow = ({
         return () => clearCurrent();
     }, [urlParams]);
 
+    const playlistShowRef = useRef();
+
     const playlistShow = title ? (
-        <div className="playlist-show">
+        <div className="playlist-show" ref={playlistShowRef}>
             <div className="playlist-header">
                 <PlaylistHeader
                     title={title}
@@ -51,6 +53,7 @@ const PlaylistShow = ({
                 urlParams={urlParams}
                 source={source}
                 songCardDropdownItems={songCardDropdownItems}
+                currentViewRef={playlistShowRef}
             />
         </div>
     ) : null;

--- a/frontend/components/playlists/playlist_show_container.js
+++ b/frontend/components/playlists/playlist_show_container.js
@@ -44,7 +44,7 @@ const mapStateToProps = (
                             title: "Create new playlist",
                         },
                         ...playlists,
-                        // Enclose array of playlists in an array since 
+                        // Enclose array of playlists in an array since
                         // dropdown uses recursive .map function on items prop
                     ],
                 ],

--- a/frontend/components/songs/song_index.jsx
+++ b/frontend/components/songs/song_index.jsx
@@ -38,16 +38,15 @@ const SongIndex = ({
         return () => {
             setSelectedSong(null);
             setSongCardDropdownState({ isOpen: false });
-        }
+        };
     }, [params]);
-    
+
     if (currentViewRef && currentViewRef.current) {
         if (songCardDropdownState.isOpen) {
             // Prevent PlaylistShow from scrolling when dropdown is open
-                currentViewRef.current.style.overflowY = "hidden";
-            }
-        else {
-                currentViewRef.current.style.overflowY = "auto";
+            currentViewRef.current.style.overflowY = "hidden";
+        } else {
+            currentViewRef.current.style.overflowY = "auto";
         }
     }
 
@@ -88,45 +87,53 @@ const SongIndex = ({
                 <div className="song-index-heading-duration">&#9201;</div>
                 <div className="song-index-heading-menu"></div>
             </div>
-            {songs.length > 0 ? 
-                (songs.map( (song, index) => {
-                    return <SongCard
-                        key={`${source} + ${song.id} + ${index}`} 
-                        source={source}
-                        song={song}
-                        history={history}
-                        index={index}
-                        songCardDropdownState={songCardDropdownState}
-                        placeSongCardDropdown={placeSongCardDropdown}
-                        updateSongCardDropdownState={updateSongCardDropdownState}
-                        updateSelectedSong={updateSelectedSong}
-                        updateDropdownMenuPointer={updateDropdownMenuPointer}
-                        dropdownPosition={dropdownPosition}
-                        dropdownMenuPointer={dropdownMenuPointer}
-                    />
-                }))
-                : null
-            }
-        </div>    
-    )
+            {songs.length > 0
+                ? songs.map((song, index) => {
+                      return (
+                          <SongCard
+                              key={`${source} + ${song.id} + ${index}`}
+                              source={source}
+                              song={song}
+                              history={history}
+                              index={index}
+                              songCardDropdownState={songCardDropdownState}
+                              placeSongCardDropdown={placeSongCardDropdown}
+                              updateSongCardDropdownState={
+                                  updateSongCardDropdownState
+                              }
+                              updateSelectedSong={updateSelectedSong}
+                              updateDropdownMenuPointer={
+                                  updateDropdownMenuPointer
+                              }
+                              dropdownPosition={dropdownPosition}
+                              dropdownMenuPointer={dropdownMenuPointer}
+                          />
+                      );
+                  })
+                : null}
+        </div>
+    );
 
     const depthLevel = 0;
-    return <>
-        {songs.length > 0 ? songIndex : emptyPlaylist}
-        {songCardDropdownState.isOpen && <SongCardDropdownContainer 
-                currentUser={currentUser}
-                history={history}
-                selectedSong={selectedSong}
-                songCardDropdownState={songCardDropdownState}
-                updateSongCardDropdownState={updateSongCardDropdownState}
-                updateDropdownPosition={updateDropdownPosition}
-                items={songCardDropdownItems}
-                depthLevel={depthLevel}
-                dropdownPosition={dropdownPosition}
-                dropdownMenuPointer={dropdownMenuPointer}
-            />
-        }
-    </>
-}
+    return (
+        <>
+            {songs.length > 0 ? songIndex : emptyPlaylist}
+            {songCardDropdownState.isOpen && (
+                <SongCardDropdownContainer
+                    currentUser={currentUser}
+                    history={history}
+                    selectedSong={selectedSong}
+                    songCardDropdownState={songCardDropdownState}
+                    updateSongCardDropdownState={updateSongCardDropdownState}
+                    updateDropdownPosition={updateDropdownPosition}
+                    items={songCardDropdownItems}
+                    depthLevel={depthLevel}
+                    dropdownPosition={dropdownPosition}
+                    dropdownMenuPointer={dropdownMenuPointer}
+                />
+            )}
+        </>
+    );
+};
 
 export default SongIndex;

--- a/frontend/components/songs/song_index.jsx
+++ b/frontend/components/songs/song_index.jsx
@@ -11,6 +11,7 @@ const SongIndex = ({
     params,
     source,
     songCardDropdownItems,
+    currentViewRef,
 }) => {
     // Set local states for SongCardDropdownState and selectedSong
     const [songCardDropdownState, setSongCardDropdownState] = useState({
@@ -39,6 +40,16 @@ const SongIndex = ({
             setSongCardDropdownState({ isOpen: false });
         }
     }, [params]);
+    
+    if (currentViewRef && currentViewRef.current) {
+        if (songCardDropdownState.isOpen) {
+            // Prevent PlaylistShow from scrolling when dropdown is open
+                currentViewRef.current.style.overflowY = "hidden";
+            }
+        else {
+                currentViewRef.current.style.overflowY = "auto";
+        }
+    }
 
     const emptyPlaylist = (
         <div className="song-index song-index-empty">


### PR DESCRIPTION
Fixes bug in #57 where SongCardDropdown was and user could still scroll the current view.
Depends on: #66 & #67.

_After fix:_

https://github.com/imartinez921/versify_full-stack/assets/102888592/87b46fa7-33e3-4c60-be6a-4f269f4a5074



