### PR TITLE
[SongCardDropdownItem] Conditionally run displayPlaylist after adding song to a playlist

### DIFF
--- a/frontend/actions/playlisted_actions.js
+++ b/frontend/actions/playlisted_actions.js
@@ -12,7 +12,6 @@ export const createNewPlaylisted = (songId, playlistId) => (dispatch) => {
     return postPlaylisted(songId, playlistId).then(
         (respObj) => {
             dispatch(fetchPlaylists());
-            dispatch(displayPlaylist(respObj.playlistId));
             return respObj.playlistId;
         },
         (err) => console.log(err)

--- a/frontend/components/songs/song_card_dropdown.jsx
+++ b/frontend/components/songs/song_card_dropdown.jsx
@@ -109,7 +109,7 @@ const SongCardDropdown = forwardRef(
                             playlists={playlists}
                             history={history}
                             currentUser={currentUser}
-                            index={index - 1} // Since the first item is "Create new playlist"
+                            selectedIndex={index - 1} // Since the first item is "Create new playlist"
                             selectedSong={selectedSong}
                             updateSongCardDropdownState={
                                 updateSongCardDropdownState

--- a/frontend/components/songs/song_card_dropdown_item.jsx
+++ b/frontend/components/songs/song_card_dropdown_item.jsx
@@ -13,6 +13,7 @@ const SongCardDropdownItem = ({
     removePlaylisted,
     createNewPlaylisted,
     createPlaylist,
+    displayPlaylist,
 }) => {
     const runSongAction = (e) => {
         if (e.target.innerText === "Remove from this playlist") {
@@ -32,9 +33,13 @@ const SongCardDropdownItem = ({
                 .then((playlistId) => history.push(`/playlist/${playlistId}`));
         } else if (depthLevel === 1) {
             updateSongCardDropdownState({ isOpen: false });
-            let playlist = playlists[index];
-            createNewPlaylisted(selectedSong.id, playlist.id)
-                .then((playlistId) => history.push(`/playlist/${playlistId}`)
+            let selectedPlaylist = playlists[index];
+            createNewPlaylisted(selectedSong.id, selectedPlaylist.id).then(
+                (selectedPlaylistId) => {
+                    if (currentItem.id === selectedPlaylistId) {
+                        displayPlaylist(selectedPlaylistId);
+                    }
+                }
             );
         }
         // } else if (e.target.innerText === "Add to queue") {

--- a/frontend/components/songs/song_card_dropdown_item.jsx
+++ b/frontend/components/songs/song_card_dropdown_item.jsx
@@ -5,7 +5,7 @@ const SongCardDropdownItem = ({
     playlists,
     currentUser,
     history,
-    index,
+    selectedIndex,
     selectedSong,
     updateSongCardDropdownState,
     item,
@@ -33,7 +33,7 @@ const SongCardDropdownItem = ({
                 .then((playlistId) => history.push(`/playlist/${playlistId}`));
         } else if (depthLevel === 1) {
             updateSongCardDropdownState({ isOpen: false });
-            let selectedPlaylist = playlists[index];
+            let selectedPlaylist = playlists[selectedIndex];
             createNewPlaylisted(selectedSong.id, selectedPlaylist.id).then(
                 (selectedPlaylistId) => {
                     if (currentItem.id === selectedPlaylistId) {


### PR DESCRIPTION
Fixes bug where every time the user added a song to the playlist, the playlist would be shown.
* It is only necessary to immediately show the playlist if the user is adding to the current playlist being viewed.
* Otherwise, only run fetchPlaylists so only the playlist list is updated.

_Bug_:

https://github.com/imartinez921/versify_full-stack/assets/102888592/db092580-8d8d-4779-8183-10714c45fd23

_After fix:_

https://github.com/imartinez921/versify_full-stack/assets/102888592/c7c755a6-d758-4cdd-95cc-eba6678dfb20

