### PR TITLE
Bug Fix: Only displayPlaylist after adding song to playlist if that selected playlist is in current view

### DIFF
--- a/frontend/actions/playlisted_actions.js
+++ b/frontend/actions/playlisted_actions.js
@@ -12,7 +12,6 @@ export const createNewPlaylisted = (songId, playlistId) => (dispatch) => {
     return postPlaylisted(songId, playlistId).then(
         (respObj) => {
             dispatch(fetchPlaylists());
-            dispatch(displayPlaylist(respObj.playlistId));
             return respObj.playlistId;
         },
         (err) => console.log(err)

--- a/frontend/components/songs/song_card_dropdown_item.jsx
+++ b/frontend/components/songs/song_card_dropdown_item.jsx
@@ -13,6 +13,7 @@ const SongCardDropdownItem = ({
     removePlaylisted,
     createNewPlaylisted,
     createPlaylist,
+    displayPlaylist,
 }) => {
     const runSongAction = (e) => {
         if (e.target.innerText === "Remove from this playlist") {
@@ -35,7 +36,11 @@ const SongCardDropdownItem = ({
             let selectedPlaylist = playlists[selectedIndex];
             createNewPlaylisted(selectedSong.id, selectedPlaylist.id).then(
                 (selectedPlaylistId) => {
-                    if (currentItem.id === selectedPlaylistId) {
+                    debugger;
+                    // If we are currently viewing a playlist (not an album), 
+                    // and we are adding the song to that current playlist, 
+                    // then re-fetch playlist
+                    if (currentItem.artistId == undefined && currentItem.id === selectedPlaylistId) {
                         displayPlaylist(selectedPlaylistId);
                     }
                 }

--- a/frontend/components/songs/song_index.jsx
+++ b/frontend/components/songs/song_index.jsx
@@ -121,10 +121,10 @@ const SongIndex = ({
             {songs.length > 0 ? songIndex : emptyPlaylist}
             {songCardDropdownState.isOpen && (
                 <SongCardDropdownContainer
+                    ref={dropdownRef}
                     currentUser={currentUser}
                     history={history}
                     selectedSong={selectedSong}
-                    ref={dropdownRef}
                     songCardDropdownState={songCardDropdownState}
                     updateSongCardDropdownState={updateSongCardDropdownState}
                     updateDropdownPosition={updateDropdownPosition}


### PR DESCRIPTION
See #69 for context.
Added back after being reverted in #76.
* Removes displayPlaylist from case when user is adding song to playlist from AlbumShow view
* Removes displayPlaylist from case when user is adding song to another playlist not in current view