### PR TITLE
[PlaylistShow] Convert children to CSS flex

### DIFF
--- a/app/assets/stylesheets/08-playlist-show.scss
+++ b/app/assets/stylesheets/08-playlist-show.scss
@@ -1,9 +1,11 @@
 .playlist-show {
     background: transparent;
     width: 100%;
-    height: calc(100vh - 85px);
+    height: 100%;
     overflow-y: auto;
     overflow-x: hidden;
+    display: flex;
+    flex-direction: column;
 }
 
 
@@ -11,8 +13,8 @@
 .playlist-header {
     background: #211a36ed;
     display: flex;
-    width: calc(100% - 30px - 30px);
-    height: calc(260px - 30px - 30px);
+    width: auto;
+    height: auto;
     padding: 30px 30px 30px 30px;
     font-family: Trebuchet MS;
     color: white;
@@ -67,10 +69,9 @@
 .playlist-nav, .album-nav {
     display: flex;
     background: #23201be6;
-    width: calc(100% - 30px);
-    height: 118px;
+    width: auto;
     align-items: center;
-    padding: 0px 0px 0px 30px;
+    padding: 25px 35px;
     gap: 25px;
 }
 
@@ -121,7 +122,7 @@ button.playlist-dropdown-button:hover {
 // PlaylistSongIndex
 .song-index {
     padding: 24px;
-    min-height: calc(100vh - (85px + 260px + 48px + 118px));
+    flex: 1 0 auto;
 }
 
 .playlist {

--- a/app/assets/stylesheets/14-song-index.scss
+++ b/app/assets/stylesheets/14-song-index.scss
@@ -30,11 +30,13 @@
 }
 
 .song-card {
-    height: 56px;
+    height: auto;
     font-family: 'Trebuchet MS', 'Lucida Sans Unicode', 'Lucida Grande', 'Lucida Sans', Arial, sans-serif;
     font-size: .9rem;
     line-height: 23px;
     margin: 5px 0px;
+    padding-top: 5px;
+    padding-bottom: 5px;
 }
 
 .song-card:hover {
@@ -46,6 +48,8 @@
 }
 
 .song-index-heading-title, .song-card-title-artist-block {
+    flex: 1 1 auto;
+    width: 400px;
     display: flex;
     flex-direction: column;
     justify-content: center;
@@ -69,6 +73,7 @@
 }
 
 .song-index-heading-album, .song-card-album {
+    flex: 1 1 auto;
     width: 400px;
 }
 


### PR DESCRIPTION
Replaces calc and pixel div sizing to CSS flex box.
Utilizes flex-grow to allow certain divs to take up remaining space. (eg.  SongIndex, song title and album columns)

_Result:_

https://github.com/imartinez921/versify_full-stack/assets/102888592/3a09dcd1-57da-44ac-8826-019255bd2a37

