### PR TITLE
Play function is broken.

### DIFF
--- a/frontend/components/page/page.jsx
+++ b/frontend/components/page/page.jsx
@@ -33,14 +33,11 @@ const Page = ({
 					/>
 				</div>
 			</div>
-			{tracks?.length>0 ? (
-				<PlayerContainer
-					params={params}
-					path={path}
-					history={history}
-					tracks={tracks}
-				/>
-			):null}
+			<PlayerContainer
+				params={params}
+				path={path}
+				history={history}
+			/>
 		</div>
 	);
 };

--- a/frontend/components/page/page_container.js
+++ b/frontend/components/page/page_container.js
@@ -5,11 +5,11 @@ import Page from "./page";
 const mapStateToProps = (state, ownProps) => ({
 	currentUser: state.entities.users[state.session.id],
 	errors: state.entities.errors,
-	// matchObj is a prop passed down by AuthRoute. matchObj = {params, path, url} as keys
+	// matchObj is a prop passed down by AuthRoute
+	// matchObj = {params, path, url} as keys
 	params: ownProps.match.params,
 	path: ownProps.match.path,
 	history: ownProps.history,
-	tracks: state.entities.nowPlaying.queue,
 });
 
 const mapDispatchToProps = (dispatch) => ({

--- a/frontend/components/player/player.jsx
+++ b/frontend/components/player/player.jsx
@@ -14,12 +14,13 @@ const Player = ({
 	const [trackIndex, setTrackIndex] = useState(0);
 	const [trackProgress, setTrackProgress] = useState(0);
 
+	// Set current track
 	let currentTrack = tracks[trackIndex];
-	let audioRef = currentTrack 
+	let audioRef = currentTrack
 		? useRef(new Audio(currentTrack.audioUrl)) // creates a new HTMLAudioElement
-		: useRef(null);
-	// // Set up play/pause behavior;
+		: useRef(new Audio());
 
+	// Set up play/pause behavior;
 	useEffect(() => {
 		if (isPlaying) {
 			audioRef.current.play();
@@ -32,7 +33,9 @@ const Player = ({
 	const isReady = useRef(false); // Avoids auto-play
 	useEffect(() => {
 		audioRef.current.pause();
-		audioRef.current.source = new Audio(currentTrack.audioUrl);
+		audioRef.current.source = currentTrack
+			? new Audio(currentTrack.audioUrl) // creates a new HTMLAudioElement
+			: new Audio();
 		setTrackProgress(audioRef.current.currentTime);
 
 		if (isReady.current) {

--- a/frontend/components/player/player.jsx
+++ b/frontend/components/player/player.jsx
@@ -12,13 +12,14 @@ const Player = ({
 }) => {
 	// Set local states
 	const [trackIndex, setTrackIndex] = useState(0);
-	const [trackProgress, setTrackProgress] = useState(0);
+	const [trackProgress, setTrackProgress] = useState(0); // progress bar
+	const [isShuffling, setIsShuffling] = useState(false);
 
 	// Set current track
 	let currentTrack = tracks[trackIndex];
 	let audioRef = currentTrack
-		? useRef(new Audio(currentTrack.audioUrl)) // creates a new HTMLAudioElement
-		: useRef(new Audio());
+		? useRef(new Audio(currentTrack.audioUrl)) // creates HTMLAudioElement
+		: useRef(new Audio()); // arg is optional
 
 	// Set up play/pause behavior;
 	useEffect(() => {
@@ -34,7 +35,7 @@ const Player = ({
 	useEffect(() => {
 		audioRef.current.pause();
 		audioRef.current.source = currentTrack
-			? new Audio(currentTrack.audioUrl) // creates a new HTMLAudioElement
+			? new Audio(currentTrack.audioUrl)
 			: new Audio();
 		setTrackProgress(audioRef.current.currentTime);
 
@@ -42,7 +43,7 @@ const Player = ({
 			audioRef.current.play();
 			reduxPlay();
 		} else {
-			// Set the isReady ref as true for the next render
+			// Set the isReady ref as true for post-initial renders
 			isReady.current = true;
 		}
 	}, [trackIndex]);
@@ -62,8 +63,10 @@ const Player = ({
 			setTrackIndex(0);
 		}
 	};
-	const shufflePlay = () => {
+	const toggleShuffle = () => {
+		if (isShuffling) return setIsShuffling(false);
 		if (tracks.length > 1) {
+			setIsShuffling(setIsShuffling(true));
 			setTrackIndex(Math.floor(Math.random() * tracks.length));
 		}
 	};
@@ -76,7 +79,7 @@ const Player = ({
 				togglePlay={reduxPlay}
 				toPrevTrack={toPrevTrack}
 				toNextTrack={toNextTrack}
-				shufflePlay={shufflePlay}
+				toggleShuffle={toggleShuffle}
 			/>
 			<div className="player-right"></div>
 		</div>

--- a/frontend/components/player/player_container.js
+++ b/frontend/components/player/player_container.js
@@ -10,7 +10,7 @@ const mapStateToProps = (state, ownProps) => {
 		params: ownProps.params,
 		path: ownProps.path,
 		history: ownProps.history,
-		tracks: ownProps.tracks,
+		tracks: state.entities.nowPlaying.queue,
 		isPlaying: state.entities.nowPlaying.isPlaying,
 	};
 };

--- a/frontend/components/player/playing_controls.jsx
+++ b/frontend/components/player/playing_controls.jsx
@@ -8,14 +8,14 @@ const PlayingControls = ({
 	togglePlay,
 	toPrevTrack,
 	toNextTrack,
-	shufflePlay,
+	toggleShuffle,
 }) => {
 	return (
 		<div className="playing-controls">
 			<BiShuffle
 				className="player__grey-icon repeat-shuffle-icon"
 				aria-label="Shuffle"
-				onClick={shufflePlay}
+				onClick={toggleShuffle}
 			/>
 			<BiSkipPrevious
 				className="player__grey-icon"


### PR DESCRIPTION
The code on the left is working code, as in the first track that loads can be played and paused. It seems that `tracks[trackIndex]` is only being defined once and never again.

However, the code on the right has broken play functionality. Currently troubleshooting.

Context: On the right side, I realized the parameter for the new Audio constructor is optional, so the code doesn't actually break if there are no tracks as long as I create a new (but empty) Audio object. But I am having trouble coding for the app to recognize when the `tracks` prop has changed (changes whenever I visit a new page with audio). Again,`tracks[trackIndex] is not being re-defined.
   On the left side, I had fetched the tracks in the parent and passed it directly to PlayerContainer so I didn't have to deal with undefined tracks.

When the component re-renders, why isn't Line 19 being read?