### PR TITLE
Expand Redux actions for playing/queuing songs from ArtistShow Page

### DIFF
--- a/app/assets/stylesheets/05-player.scss
+++ b/app/assets/stylesheets/05-player.scss
@@ -69,11 +69,11 @@
 }
 
 svg.player__white-icon > path {
-    fill: white;
+    color: white;
 }
 
 svg.player__grey-icon > path {
-    fill: #b3b2b2;;
+    color: #b3b2b2;
 }
 
 .player-right {

--- a/app/assets/stylesheets/08-playlist-show.scss
+++ b/app/assets/stylesheets/08-playlist-show.scss
@@ -75,7 +75,7 @@
     gap: 25px;
 }
 
-#playlist-play-button, #artist-play-button {
+#playlist-play-button {
     display: flex;
     background: #34d760;
     height: 56px;

--- a/app/assets/stylesheets/12-artist-show.scss
+++ b/app/assets/stylesheets/12-artist-show.scss
@@ -58,10 +58,31 @@
 }
 
 .artist-dropdown {
-    left: 145px;
+    left: 169px;
     top: 386px;
     align-items: flex-start;
     min-width: 140px;
+}
+
+#artist-play-button {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+#artist-play-button svg {
+    font-size: 70px;
+}
+
+#artist-play-button svg path{
+    font-size: 60px;
+    color: #34d760;
+}
+
+#artist-play-button svg:hover {
+    cursor: pointer;
+    transition: 0.2s ease;
+    transform: scale(1.2) !important;
 }
 
 

--- a/app/assets/stylesheets/12-artist-show.scss
+++ b/app/assets/stylesheets/12-artist-show.scss
@@ -71,10 +71,6 @@
 }
 
 #artist-play-button svg {
-    font-size: 70px;
-}
-
-#artist-play-button svg path{
     font-size: 60px;
     color: #34d760;
 }

--- a/app/assets/stylesheets/12-artist-show.scss
+++ b/app/assets/stylesheets/12-artist-show.scss
@@ -82,7 +82,7 @@
 #artist-play-button svg:hover {
     cursor: pointer;
     transition: 0.2s ease;
-    transform: scale(1.2) !important;
+    transform: scale(1.1) !important;
 }
 
 

--- a/app/controllers/api/artists_controller.rb
+++ b/app/controllers/api/artists_controller.rb
@@ -7,7 +7,7 @@ class Api::ArtistsController < ApplicationController
 
     def show
         @artist = Artist
-            .includes(:albums, collab_songs: [{album: :album_artist}, :collab_artists])
+            .includes(albums:[:tracks], collab_songs: [:collab_artists])
             .order("albums.year DESC")
             .find(params[:id])
         if @artist

--- a/frontend/actions/now_playing_actions.js
+++ b/frontend/actions/now_playing_actions.js
@@ -22,6 +22,5 @@ export const reduxPlay = () => dispatch => (
 );
 
 export const toQueueArtist = (queueObj) => dispatch => {
-    debugger
     return dispatch(queueArtist(queueObj));
 }

--- a/frontend/actions/now_playing_actions.js
+++ b/frontend/actions/now_playing_actions.js
@@ -24,6 +24,6 @@ export const reduxPlay = () => dispatch => (
     dispatch(togglePlay())
 );
 
-export const albumQueue = (songsArray) => dispatch => {
+export const toQueueAlbum = (songsArray) => dispatch => {
     return dispatch(queueAlbum(songsArray));
 }

--- a/frontend/actions/now_playing_actions.js
+++ b/frontend/actions/now_playing_actions.js
@@ -1,13 +1,10 @@
-export const TOGGLE_PLAY = 'TOGGLE_PLAY'
-export const QUEUE_ARTIST = 'QUEUE_ARTIST'
+export const TOGGLE_PLAY = "TOGGLE_PLAY";
+export const QUEUE_ARTIST = "QUEUE_ARTIST";
+export const PLAY_ARTIST = "PLAY_ARTIST";
 
 const togglePlay = () => ({
-    type: TOGGLE_PLAY,
-})
-
-const queueSong = () => ({
-    type: QUEUE_SONG,
-})
+	type: TOGGLE_PLAY,
+});
 
 const queueArtist = (queueObj) => ({
 	//{allSongs:arr, sourceType:str, extractedUrlParams:numStr}
@@ -17,10 +14,20 @@ const queueArtist = (queueObj) => ({
 	extractedUrlParams: queueObj.extractedUrlParams,
 });
 
-export const reduxPlay = () => dispatch => (
-    dispatch(togglePlay())
-);
+const playArtist = (queueObj) => ({
+	//{allSongs:arr, sourceType:str, extractedUrlParams:numStr}
+	type: PLAY_ARTIST,
+	allSongs: queueObj.allSongs,
+	sourceType: queueObj.sourceType,
+	extractedUrlParams: queueObj.extractedUrlParams,
+});
 
-export const toQueueArtist = (queueObj) => dispatch => {
-    return dispatch(queueArtist(queueObj));
-}
+export const reduxPlay = () => (dispatch) => dispatch(togglePlay());
+
+export const toQueueArtist = (queueObj) => (dispatch) => {
+	return dispatch(queueArtist(queueObj));
+};
+
+export const toPlayArtist = (queueObj) => (dispatch) => {
+	return dispatch(playArtist(queueObj));
+};

--- a/frontend/actions/now_playing_actions.js
+++ b/frontend/actions/now_playing_actions.js
@@ -1,19 +1,29 @@
 export const TOGGLE_PLAY = 'TOGGLE_PLAY'
-export const PLAY_ALBUM = 'PLAY_ALBUM'
-export const PLAY_PLAYLIST = 'PLAY_PLAYLIST'
+export const QUEUE_SONG = 'QUEUE_SONG'
+export const QUEUE_ALBUM = 'QUEUE_ALBUM'
+export const QUEUE_PLAYLIST = 'QUEUE_PLAYLIST'
 
 const togglePlay = () => ({
     type: TOGGLE_PLAY,
 })
 
-const playAlbum = () => ({
-    type: PLAY_ALBUM,
+const queueSong = () => ({
+    type: QUEUE_SONG,
 })
 
-const playPlaylist = () => ({
-    type: PLAY_PLAYLIST,
+const queueAlbum = (songsArray) => ({
+    type: QUEUE_ALBUM,
+    songs: songsArray,
+})
+
+const queuePlaylist = () => ({
+    type: QUEUE_PLAYLIST,
 })
 
 export const reduxPlay = () => dispatch => (
     dispatch(togglePlay())
 );
+
+export const albumQueue = (songsArray) => dispatch => {
+    return dispatch(queueAlbum(songsArray));
+}

--- a/frontend/actions/now_playing_actions.js
+++ b/frontend/actions/now_playing_actions.js
@@ -27,7 +27,7 @@ const playArtist = (queueObj) => ({
 	extractedUrlParams: queueObj.extractedUrlParams,
 });
 
-export const reduxPlay = () => (dispatch) => dispatch(togglePlay());
+export const toTogglePlay = () => (dispatch) => dispatch(togglePlay());
 
 export const toQueueArtist = (queueObj) => (dispatch) => {
 	return dispatch(queueArtist(queueObj));

--- a/frontend/actions/now_playing_actions.js
+++ b/frontend/actions/now_playing_actions.js
@@ -11,9 +11,10 @@ const queueSong = () => ({
     type: QUEUE_SONG,
 })
 
-const queueArtist = (songsArray) => ({
+const queueArtist = (songsArray, urlParams) => ({
     type: QUEUE_ARTIST,
     songs: songsArray,
+    urlParams: urlParams,
 })
 
 const queuePlaylist = () => ({
@@ -24,6 +25,6 @@ export const reduxPlay = () => dispatch => (
     dispatch(togglePlay())
 );
 
-export const toQueueArtist = (songsArray) => dispatch => {
-    return dispatch(queueArtist(songsArray));
+export const toQueueArtist = (songsArray, urlParams) => dispatch => {
+    return dispatch(queueArtist(songsArray, urlParams));
 }

--- a/frontend/actions/now_playing_actions.js
+++ b/frontend/actions/now_playing_actions.js
@@ -1,6 +1,6 @@
 export const TOGGLE_PLAY = 'TOGGLE_PLAY'
 export const QUEUE_SONG = 'QUEUE_SONG'
-export const QUEUE_ALBUM = 'QUEUE_ALBUM'
+export const QUEUE_ARTIST = 'QUEUE_ARTIST'
 export const QUEUE_PLAYLIST = 'QUEUE_PLAYLIST'
 
 const togglePlay = () => ({
@@ -12,7 +12,7 @@ const queueSong = () => ({
 })
 
 const queueArtist = (songsArray) => ({
-    type: QUEUE_ALBUM,
+    type: QUEUE_ARTIST,
     songs: songsArray,
 })
 

--- a/frontend/actions/now_playing_actions.js
+++ b/frontend/actions/now_playing_actions.js
@@ -11,7 +11,7 @@ const queueSong = () => ({
     type: QUEUE_SONG,
 })
 
-const queueAlbum = (songsArray) => ({
+const queueArtist = (songsArray) => ({
     type: QUEUE_ALBUM,
     songs: songsArray,
 })
@@ -24,6 +24,6 @@ export const reduxPlay = () => dispatch => (
     dispatch(togglePlay())
 );
 
-export const toQueueAlbum = (songsArray) => dispatch => {
-    return dispatch(queueAlbum(songsArray));
+export const toQueueArtist = (songsArray) => dispatch => {
+    return dispatch(queueArtist(songsArray));
 }

--- a/frontend/actions/now_playing_actions.js
+++ b/frontend/actions/now_playing_actions.js
@@ -1,7 +1,5 @@
 export const TOGGLE_PLAY = 'TOGGLE_PLAY'
-export const QUEUE_SONG = 'QUEUE_SONG'
 export const QUEUE_ARTIST = 'QUEUE_ARTIST'
-export const QUEUE_PLAYLIST = 'QUEUE_PLAYLIST'
 
 const togglePlay = () => ({
     type: TOGGLE_PLAY,
@@ -11,20 +9,19 @@ const queueSong = () => ({
     type: QUEUE_SONG,
 })
 
-const queueArtist = (songsArray, urlParams) => ({
-    type: QUEUE_ARTIST,
-    songs: songsArray,
-    urlParams: urlParams,
-})
-
-const queuePlaylist = () => ({
-    type: QUEUE_PLAYLIST,
-})
+const queueArtist = (queueObj) => ({
+	//{allSongs:arr, sourceType:str, extractedUrlParams:numStr}
+	type: QUEUE_ARTIST,
+	allSongs: queueObj.allSongs,
+	sourceType: queueObj.sourceType,
+	extractedUrlParams: queueObj.extractedUrlParams,
+});
 
 export const reduxPlay = () => dispatch => (
     dispatch(togglePlay())
 );
 
-export const toQueueArtist = (songsArray, urlParams) => dispatch => {
-    return dispatch(queueArtist(songsArray, urlParams));
+export const toQueueArtist = (queueObj) => dispatch => {
+    debugger
+    return dispatch(queueArtist(queueObj));
 }

--- a/frontend/actions/now_playing_actions.js
+++ b/frontend/actions/now_playing_actions.js
@@ -1,9 +1,14 @@
 export const TOGGLE_PLAY = "TOGGLE_PLAY";
+export const PUSH_PLAY = "PUSH_PLAY";
 export const QUEUE_ARTIST = "QUEUE_ARTIST";
 export const PLAY_ARTIST = "PLAY_ARTIST";
 
 const togglePlay = () => ({
 	type: TOGGLE_PLAY,
+});
+
+const pushPlay = () => ({
+	type: PUSH_PLAY,
 });
 
 const queueArtist = (queueObj) => ({
@@ -31,3 +36,5 @@ export const toQueueArtist = (queueObj) => (dispatch) => {
 export const toPlayArtist = (queueObj) => (dispatch) => {
 	return dispatch(playArtist(queueObj));
 };
+
+export const toPushPlay = () => (dispatch) => dispatch(pushPlay())

--- a/frontend/components/artists/artist_page_dropdown.jsx
+++ b/frontend/components/artists/artist_page_dropdown.jsx
@@ -7,12 +7,11 @@ const ArtistPageDropdown = forwardRef(
 		{ // unused props will be for submenu refactoring
 			playlists,
 			allSongs,
+			handleAddToQueue,
 			history,
 			artistPageDropdownState,
-			artistShowRef,
 			toggleArtistPageDropdown,
 			items,
-			toQueueArtist,
 		},
 		ref
 	) => {
@@ -59,8 +58,7 @@ const ArtistPageDropdown = forwardRef(
 							<ArtistPageDropdownItem
 								key={`${item.id} + ${index}`}
 								item={item}
-								allSongs={allSongs}
-								toQueueArtist={toQueueArtist}
+								handleAddToQueue={handleAddToQueue}
 							/>
 						)
 					)}

--- a/frontend/components/artists/artist_page_dropdown.jsx
+++ b/frontend/components/artists/artist_page_dropdown.jsx
@@ -5,14 +5,14 @@ import ArtistPageDropdownItem from "./artist_page_dropdown_item";
 const ArtistPageDropdown = forwardRef(
 	(
 		{ // unused props will be for submenu refactoring
+			playlists,
+			allSongs,
 			history,
 			artistPageDropdownState,
 			artistShowRef,
 			toggleArtistPageDropdown,
-			playlists,
-			allSongs,
 			items,
-			fetchPlaylists,
+			toQueueAlbum,
 		},
 		ref
 	) => {
@@ -49,15 +49,19 @@ const ArtistPageDropdown = forwardRef(
 
 		return (
 			<>
-				<div className="dropdown-item artist-dropdown"
-				ref={ref}>
+				<div className="dropdown-item artist-dropdown" ref={ref}>
 					{items.map((item, index) =>
 						item.submenu ? (
 							{
 								/* TODO: Implement submenu logic */
 							}
 						) : (
-							<ArtistPageDropdownItem key={`${item.id} + ${index}`} item={item} />
+							<ArtistPageDropdownItem
+								key={`${item.id} + ${index}`}
+								item={item}
+								allSongs={allSongs}
+								toQueueAlbum={toQueueAlbum}
+							/>
 						)
 					)}
 				</div>

--- a/frontend/components/artists/artist_page_dropdown.jsx
+++ b/frontend/components/artists/artist_page_dropdown.jsx
@@ -12,7 +12,7 @@ const ArtistPageDropdown = forwardRef(
 			artistShowRef,
 			toggleArtistPageDropdown,
 			items,
-			toQueueAlbum,
+			toQueueArtist,
 		},
 		ref
 	) => {
@@ -60,7 +60,7 @@ const ArtistPageDropdown = forwardRef(
 								key={`${item.id} + ${index}`}
 								item={item}
 								allSongs={allSongs}
-								toQueueAlbum={toQueueAlbum}
+								toQueueArtist={toQueueArtist}
 							/>
 						)
 					)}

--- a/frontend/components/artists/artist_page_dropdown_container.js
+++ b/frontend/components/artists/artist_page_dropdown_container.js
@@ -1,5 +1,5 @@
 import { connect } from "react-redux";
-import { toQueueAlbum } from "../../actions/now_playing_actions";
+import { toQueueArtist } from "../../actions/now_playing_actions";
 
 import ArtistPageDropdown from "./artist_page_dropdown";
 
@@ -37,7 +37,7 @@ const mapStateToProps = (state, ownProps) => {
 };
 
 const mapDispatchToProps = (dispatch) => ({
-	toQueueAlbum: (songsArray) => dispatch(toQueueAlbum(songsArray)),
+	toQueueArtist: (songsArray) => dispatch(toQueueArtist(songsArray)),
 });
 
 export default connect(mapStateToProps, mapDispatchToProps, null, {forwardRef: true})(ArtistPageDropdown);

--- a/frontend/components/artists/artist_page_dropdown_container.js
+++ b/frontend/components/artists/artist_page_dropdown_container.js
@@ -37,7 +37,7 @@ const mapStateToProps = (state, ownProps) => {
 };
 
 const mapDispatchToProps = (dispatch) => ({
-	toQueueArtist: (songsArray) => dispatch(toQueueArtist(songsArray)),
+	toQueueArtist: (queueObj) => dispatch(toQueueArtist(queueObj)),
 });
 
 export default connect(mapStateToProps, mapDispatchToProps, null, {forwardRef: true})(ArtistPageDropdown);

--- a/frontend/components/artists/artist_page_dropdown_container.js
+++ b/frontend/components/artists/artist_page_dropdown_container.js
@@ -1,17 +1,18 @@
 import { connect } from "react-redux";
+import { toQueueAlbum } from "../../actions/now_playing_actions";
 
 import ArtistPageDropdown from "./artist_page_dropdown";
 
 const mapStateToProps = (state, ownProps) => {
 	return {
+		playlists: state.entities.playlists,
+		allSongs: state.entities.songs.allSongs,
 		currentArtist: ownProps.currentArtist,
 		history: ownProps.history,
 		artistPageDropdownState: ownProps.artistPageDropdownState,
 		artistShowRef: ownProps.artistShowRef,
 		ref: ownProps.ref,
 		toggleArtistPageDropdown: ownProps.toggleArtistPageDropdown,
-		playlists: state.entities.playlists,
-		allSongs: state.entities.songs.allSongs,
 		items: [
 			// TODO: Implement adding artist songs to playlist
 			// {title: "Add to playlist",
@@ -36,7 +37,7 @@ const mapStateToProps = (state, ownProps) => {
 };
 
 const mapDispatchToProps = (dispatch) => ({
-	fetchPlaylists: () => dispatch(fetchPlaylists()),
+	toQueueAlbum: (songsArray) => dispatch(toQueueAlbum(songsArray)),
 });
 
 export default connect(mapStateToProps, mapDispatchToProps, null, {forwardRef: true})(ArtistPageDropdown);

--- a/frontend/components/artists/artist_page_dropdown_container.js
+++ b/frontend/components/artists/artist_page_dropdown_container.js
@@ -7,10 +7,9 @@ const mapStateToProps = (state, ownProps) => {
 	return {
 		playlists: state.entities.playlists,
 		allSongs: state.entities.songs.allSongs,
-		currentArtist: ownProps.currentArtist,
+		handleAddToQueue: ownProps.handleAddToQueue,
 		history: ownProps.history,
 		artistPageDropdownState: ownProps.artistPageDropdownState,
-		artistShowRef: ownProps.artistShowRef,
 		ref: ownProps.ref,
 		toggleArtistPageDropdown: ownProps.toggleArtistPageDropdown,
 		items: [

--- a/frontend/components/artists/artist_page_dropdown_item.jsx
+++ b/frontend/components/artists/artist_page_dropdown_item.jsx
@@ -1,7 +1,14 @@
 import React from "react";
 
-const ArtistPageDropdownItem = ({ item }) => {
-	return <button className="playlist-dropdown-button">{item.title}</button>;
+const ArtistPageDropdownItem = ({ item, allSongs, toQueueAlbum }) => {
+	const runAlbumAction = (e) => {
+		if (e.target.innerText === "Add to queue") {
+            toQueueAlbum(allSongs);
+		}
+	};
+	return <button 
+        className="playlist-dropdown-button"
+        onClick={runAlbumAction}>{item.title}</button>;
 };
 
 export default ArtistPageDropdownItem;

--- a/frontend/components/artists/artist_page_dropdown_item.jsx
+++ b/frontend/components/artists/artist_page_dropdown_item.jsx
@@ -1,9 +1,9 @@
 import React from "react";
 
-const ArtistPageDropdownItem = ({ item, allSongs, toQueueAlbum }) => {
+const ArtistPageDropdownItem = ({ item, allSongs, toQueueArtist }) => {
 	const runAlbumAction = (e) => {
 		if (e.target.innerText === "Add to queue") {
-            toQueueAlbum(allSongs);
+            toQueueArtist(allSongs);
 		}
 	};
 	return <button 

--- a/frontend/components/artists/artist_page_dropdown_item.jsx
+++ b/frontend/components/artists/artist_page_dropdown_item.jsx
@@ -1,14 +1,16 @@
 import React from "react";
 
-const ArtistPageDropdownItem = ({ item, allSongs, toQueueArtist }) => {
+const ArtistPageDropdownItem = ({ item, handleAddToQueue }) => {
 	const runAlbumAction = (e) => {
 		if (e.target.innerText === "Add to queue") {
-            toQueueArtist(allSongs);
+			handleAddToQueue(e);
 		}
 	};
-	return <button 
-        className="playlist-dropdown-button"
-        onClick={runAlbumAction}>{item.title}</button>;
+	return (
+		<button className="playlist-dropdown-button" onClick={runAlbumAction}>
+			{item.title}
+		</button>
+	);
 };
 
 export default ArtistPageDropdownItem;

--- a/frontend/components/artists/artist_page_menu_bar.jsx
+++ b/frontend/components/artists/artist_page_menu_bar.jsx
@@ -8,7 +8,7 @@ const ArtistPageMenuBar = ({
 	artistShowRef,
 	allSongs,
 	reduxPlay,
-	toQueueAlbum,
+	toQueueArtist,
 	history,
 }) => {
 	const [artistPageDropdownState, setArtistPageDropdownState] = useState({
@@ -32,7 +32,7 @@ const ArtistPageMenuBar = ({
 
 	const handleButtonClick = (e) => {
 		e.preventDefault();
-		toQueueAlbum(allSongs);
+		toQueueArtist(allSongs);
 		reduxPlay();
 	}
 

--- a/frontend/components/artists/artist_page_menu_bar.jsx
+++ b/frontend/components/artists/artist_page_menu_bar.jsx
@@ -11,6 +11,7 @@ const ArtistPageMenuBar = ({
 	artistShowRef,
 	allSongs,
 	isPlaying,
+	queueSource,
 	reduxPlay,
 	toQueueArtist,
 	history,

--- a/frontend/components/artists/artist_page_menu_bar.jsx
+++ b/frontend/components/artists/artist_page_menu_bar.jsx
@@ -12,7 +12,7 @@ const ArtistPageMenuBar = ({
 	allSongs,
 	isPlaying,
 	queueSource,
-	reduxPlay,
+	toTogglePlay,
 	toQueueArtist,
 	toPlayArtist,
 	toPushPlay,
@@ -48,7 +48,7 @@ const ArtistPageMenuBar = ({
 			queueObj.sourceType === queueSource.sourceType &&
 			queueObj.extractedUrlParams === queueSource.extractedUrlParams
 		) {
-			reduxPlay();
+			toTogglePlay();
 		} else {
 			toPlayArtist(queueObj);
 			toPushPlay();

--- a/frontend/components/artists/artist_page_menu_bar.jsx
+++ b/frontend/components/artists/artist_page_menu_bar.jsx
@@ -15,6 +15,7 @@ const ArtistPageMenuBar = ({
 	reduxPlay,
 	toQueueArtist,
 	history,
+	urlParams,
 }) => {
 	const [artistPageDropdownState, setArtistPageDropdownState] = useState({
 		isOpen: false,
@@ -22,9 +23,6 @@ const ArtistPageMenuBar = ({
 	const toggleArtistPageDropdown = () => {
 		setArtistPageDropdownState({ isOpen: !artistPageDropdownState.isOpen });
 	};
-
-	// Create dropdown ref in parent component in order to wrap Redux container
-	const dropdownRef = useRef();
 
 	// Prevent ArtistShow from scrolling when dropdown is open
 	if (artistShowRef && artistShowRef.current) {
@@ -35,16 +33,27 @@ const ArtistPageMenuBar = ({
 		}
 	}
 
+	const queueObj = {
+		allSongs,
+		sourceType: "artist",
+		extractedUrlParams: urlParams.id,
+	}; // extract id
+	console.log(queueObj)
+	console.log(queueSource)
 	const handleButtonClick = (e) => {
 		e.preventDefault();
-		toQueueArtist(allSongs);
+		toQueueArtist(queueObj);
 		reduxPlay();
 	};
 
+	// Create dropdown ref in parent component in order to wrap Redux container
+	const dropdownRef = useRef();
 	return (
 		<>
 			<div id="artist-play-button" onClick={handleButtonClick}>
-				{isPlaying ? (
+				{isPlaying &&
+				(queueObj.sourceType === queueSource.sourceType &&
+				queueObj.extractedUrlParams === queueSource.extractedUrlParams) ? (
 					<MdOutlinePauseCircleFilled />
 				) : (
 					<MdOutlinePlayCircleFilled />

--- a/frontend/components/artists/artist_page_menu_bar.jsx
+++ b/frontend/components/artists/artist_page_menu_bar.jsx
@@ -15,6 +15,7 @@ const ArtistPageMenuBar = ({
 	reduxPlay,
 	toQueueArtist,
 	toPlayArtist,
+	toPushPlay,
 	history,
 	urlParams,
 }) => {
@@ -39,13 +40,19 @@ const ArtistPageMenuBar = ({
 		sourceType: "artist",
 		extractedUrlParams: urlParams.id,
 	}; // provides linkback to view currently playing
-	// TODO: Implement queue view)
+	// TODO: Implement queue view
 
 	const handleButtonClick = (e) => {
 		e.preventDefault();
-		reduxPlay();
-		toPlayArtist(queueObj)
-		reduxPlay();
+		if (
+			queueObj.sourceType === queueSource.sourceType &&
+			queueObj.extractedUrlParams === queueSource.extractedUrlParams
+		) {
+			reduxPlay();
+		} else {
+			toPlayArtist(queueObj);
+			toPushPlay();
+		}
 	};
 
 	const handleAddToQueue = (e) => {

--- a/frontend/components/artists/artist_page_menu_bar.jsx
+++ b/frontend/components/artists/artist_page_menu_bar.jsx
@@ -14,6 +14,7 @@ const ArtistPageMenuBar = ({
 	queueSource,
 	reduxPlay,
 	toQueueArtist,
+	toPlayArtist,
 	history,
 	urlParams,
 }) => {
@@ -38,9 +39,16 @@ const ArtistPageMenuBar = ({
 		sourceType: "artist",
 		extractedUrlParams: urlParams.id,
 	}; // provides linkback to view currently playing
-	// TODO: Implement queue view
+	// TODO: Implement queue view)
 
 	const handleButtonClick = (e) => {
+		e.preventDefault();
+		reduxPlay();
+		toPlayArtist(queueObj)
+		reduxPlay();
+	};
+
+	const handleAddToQueue = (e) => {
 		e.preventDefault();
 		toQueueArtist(queueObj);
 		setArtistPageDropdownState({ isOpen: false });
@@ -65,7 +73,7 @@ const ArtistPageMenuBar = ({
 			</div>
 			{artistPageDropdownState.isOpen && (
 				<ArtistPageDropdownContainer
-					handleAddToQueue={handleButtonClick}
+					handleAddToQueue={handleAddToQueue}
 					history={history}
 					artistPageDropdownState={artistPageDropdownState}
 					ref={dropdownRef}

--- a/frontend/components/artists/artist_page_menu_bar.jsx
+++ b/frontend/components/artists/artist_page_menu_bar.jsx
@@ -6,6 +6,9 @@ import { GrPlayFill } from "react-icons/gr";
 
 const ArtistPageMenuBar = ({
 	artistShowRef,
+	allSongs,
+	reduxPlay,
+	toQueueAlbum,
 	history,
 }) => {
 	const [artistPageDropdownState, setArtistPageDropdownState] = useState({
@@ -27,10 +30,16 @@ const ArtistPageMenuBar = ({
 		}
 	}
 
+	const handleButtonClick = (e) => {
+		e.preventDefault();
+		toQueueAlbum(allSongs);
+		reduxPlay();
+	}
+
 	return (
 		<>
 			<div id="artist-play-button">
-				<GrPlayFill />
+				<GrPlayFill onClick={handleButtonClick} />
 				{/* TODO: Show pause button when Redux isPlaying=true */}
 			</div>
 			<div id="artist-dropdown-dots">

--- a/frontend/components/artists/artist_page_menu_bar.jsx
+++ b/frontend/components/artists/artist_page_menu_bar.jsx
@@ -37,13 +37,13 @@ const ArtistPageMenuBar = ({
 		allSongs,
 		sourceType: "artist",
 		extractedUrlParams: urlParams.id,
-	}; // extract id
-	console.log(queueObj)
-	console.log(queueSource)
+	}; // provides linkback to view currently playing
+	// TODO: Implement queue view
+
 	const handleButtonClick = (e) => {
 		e.preventDefault();
 		toQueueArtist(queueObj);
-		reduxPlay();
+		setArtistPageDropdownState({ isOpen: false });
 	};
 
 	// Create dropdown ref in parent component in order to wrap Redux container
@@ -52,8 +52,9 @@ const ArtistPageMenuBar = ({
 		<>
 			<div id="artist-play-button" onClick={handleButtonClick}>
 				{isPlaying &&
-				(queueObj.sourceType === queueSource.sourceType &&
-				queueObj.extractedUrlParams === queueSource.extractedUrlParams) ? (
+				queueObj.sourceType === queueSource.sourceType &&
+				queueObj.extractedUrlParams ===
+					queueSource.extractedUrlParams ? (
 					<MdOutlinePauseCircleFilled />
 				) : (
 					<MdOutlinePlayCircleFilled />
@@ -64,9 +65,9 @@ const ArtistPageMenuBar = ({
 			</div>
 			{artistPageDropdownState.isOpen && (
 				<ArtistPageDropdownContainer
+					handleAddToQueue={handleButtonClick}
 					history={history}
 					artistPageDropdownState={artistPageDropdownState}
-					artistShowRef={artistShowRef}
 					ref={dropdownRef}
 					toggleArtistPageDropdown={toggleArtistPageDropdown}
 				/>

--- a/frontend/components/artists/artist_page_menu_bar.jsx
+++ b/frontend/components/artists/artist_page_menu_bar.jsx
@@ -1,12 +1,16 @@
-import React, { useRef, useState } from "react";
+import React, { useRef, useState, useEffect } from "react";
 import ArtistPageDropdownContainer from "./artist_page_dropdown_container";
 
 import { RxDotsHorizontal } from "react-icons/rx";
-import { GrPlayFill } from "react-icons/gr";
+import {
+	MdOutlinePlayCircleFilled,
+	MdOutlinePauseCircleFilled,
+} from "react-icons/md";
 
 const ArtistPageMenuBar = ({
 	artistShowRef,
 	allSongs,
+	isPlaying,
 	reduxPlay,
 	toQueueArtist,
 	history,
@@ -21,9 +25,9 @@ const ArtistPageMenuBar = ({
 	// Create dropdown ref in parent component in order to wrap Redux container
 	const dropdownRef = useRef();
 
+	// Prevent ArtistShow from scrolling when dropdown is open
 	if (artistShowRef && artistShowRef.current) {
 		if (artistPageDropdownState.isOpen) {
-			// Prevent ArtistShow from scrolling when dropdown is open
 			artistShowRef.current.style.overflowY = "hidden";
 		} else {
 			artistShowRef.current.style.overflowY = "auto";
@@ -34,13 +38,16 @@ const ArtistPageMenuBar = ({
 		e.preventDefault();
 		toQueueArtist(allSongs);
 		reduxPlay();
-	}
+	};
 
 	return (
 		<>
-			<div id="artist-play-button">
-				<GrPlayFill onClick={handleButtonClick} />
-				{/* TODO: Show pause button when Redux isPlaying=true */}
+			<div id="artist-play-button" onClick={handleButtonClick}>
+				{isPlaying ? (
+					<MdOutlinePauseCircleFilled />
+				) : (
+					<MdOutlinePlayCircleFilled />
+				)}
 			</div>
 			<div id="artist-dropdown-dots">
 				<RxDotsHorizontal onClick={toggleArtistPageDropdown} />

--- a/frontend/components/artists/artist_show.jsx
+++ b/frontend/components/artists/artist_show.jsx
@@ -12,7 +12,7 @@ const ArtistShow = ({
 	collabSongs,
 	isPlaying,
 	queueSource,
-	params,
+	urlParams,
 	path,
 	currentUser,
 	history,
@@ -23,7 +23,7 @@ const ArtistShow = ({
 	clearCurrent,
 }) => {
 	useEffect(() => {
-		displayArtist(params.id);
+		displayArtist(urlParams.id);
 
 		const rendered = document.getElementById("artist-show");
 		rendered ? rendered.scrollTo(0, 0) : null;
@@ -31,7 +31,7 @@ const ArtistShow = ({
 		return () => {
 			clearCurrent();
 		};
-	}, [params]); // Will run whenever params.id changes, otherwise ArtistShow doesn't re-render
+	}, [urlParams]); // Will run whenever urlParams.id changes, otherwise ArtistShow doesn't re-render
 
 	const artistShowRef = useRef();
 
@@ -56,6 +56,7 @@ const ArtistShow = ({
 							reduxPlay={reduxPlay}
 							toQueueArtist={toQueueArtist}
 							history={history}
+							urlParams={urlParams}
 						/>
 					</div>
 					{albums?.length > 0 && (

--- a/frontend/components/artists/artist_show.jsx
+++ b/frontend/components/artists/artist_show.jsx
@@ -18,7 +18,7 @@ const ArtistShow = ({
 	history,
 	displayArtist,
 	displayAlbum,
-	reduxPlay,
+	toTogglePlay,
 	toQueueArtist,
 	toPlayArtist,
 	toPushPlay,
@@ -55,7 +55,7 @@ const ArtistShow = ({
 							allSongs={allSongs}
 							isPlaying={isPlaying}
 							queueSource={queueSource}
-							reduxPlay={reduxPlay}
+							toTogglePlay={toTogglePlay}
 							toQueueArtist={toQueueArtist}
 							toPlayArtist={toPlayArtist}
 							toPushPlay={toPushPlay}

--- a/frontend/components/artists/artist_show.jsx
+++ b/frontend/components/artists/artist_show.jsx
@@ -20,6 +20,7 @@ const ArtistShow = ({
 	displayAlbum,
 	reduxPlay,
 	toQueueArtist,
+	toPlayArtist,
 	clearCurrent,
 }) => {
 	useEffect(() => {
@@ -55,6 +56,7 @@ const ArtistShow = ({
 							queueSource={queueSource}
 							reduxPlay={reduxPlay}
 							toQueueArtist={toQueueArtist}
+							toPlayArtist={toPlayArtist}
 							history={history}
 							urlParams={urlParams}
 						/>

--- a/frontend/components/artists/artist_show.jsx
+++ b/frontend/components/artists/artist_show.jsx
@@ -11,6 +11,7 @@ const ArtistShow = ({
 	allSongs,
 	collabSongs,
 	isPlaying,
+	queueSource,
 	params,
 	path,
 	currentUser,
@@ -51,6 +52,7 @@ const ArtistShow = ({
 							artistShowRef={artistShowRef}
 							allSongs={allSongs}
 							isPlaying={isPlaying}
+							queueSource={queueSource}
 							reduxPlay={reduxPlay}
 							toQueueArtist={toQueueArtist}
 							history={history}

--- a/frontend/components/artists/artist_show.jsx
+++ b/frontend/components/artists/artist_show.jsx
@@ -10,6 +10,7 @@ const ArtistShow = ({
 	albums,
 	allSongs,
 	collabSongs,
+	isPlaying,
 	params,
 	path,
 	currentUser,
@@ -49,6 +50,7 @@ const ArtistShow = ({
 						<ArtistPageMenuBar
 							artistShowRef={artistShowRef}
 							allSongs={allSongs}
+							isPlaying={isPlaying}
 							reduxPlay={reduxPlay}
 							toQueueArtist={toQueueArtist}
 							history={history}

--- a/frontend/components/artists/artist_show.jsx
+++ b/frontend/components/artists/artist_show.jsx
@@ -8,6 +8,7 @@ import CollabSongIndex from "../songs/collab_song_index";
 const ArtistShow = ({
 	currentArtist,
 	albums,
+	allSongs,
 	collabSongs,
 	params,
 	path,
@@ -15,6 +16,8 @@ const ArtistShow = ({
 	history,
 	displayArtist,
 	displayAlbum,
+	reduxPlay,
+	toQueueAlbum,
 	clearCurrent,
 }) => {
 	useEffect(() => {
@@ -45,6 +48,9 @@ const ArtistShow = ({
 					<div className="artist-nav">
 						<ArtistPageMenuBar
 							artistShowRef={artistShowRef}
+							allSongs={allSongs}
+							reduxPlay={reduxPlay}
+							toQueueAlbum={toQueueAlbum}
 							history={history}
 						/>
 					</div>
@@ -59,7 +65,6 @@ const ArtistShow = ({
 						<CollabSongIndex
 							songs={collabSongs}
 							history={history}
-							
 							displayAlbum={displayAlbum}
 							currentArtist={currentArtist}
 						/>

--- a/frontend/components/artists/artist_show.jsx
+++ b/frontend/components/artists/artist_show.jsx
@@ -21,6 +21,7 @@ const ArtistShow = ({
 	reduxPlay,
 	toQueueArtist,
 	toPlayArtist,
+	toPushPlay,
 	clearCurrent,
 }) => {
 	useEffect(() => {
@@ -57,6 +58,7 @@ const ArtistShow = ({
 							reduxPlay={reduxPlay}
 							toQueueArtist={toQueueArtist}
 							toPlayArtist={toPlayArtist}
+							toPushPlay={toPushPlay}
 							history={history}
 							urlParams={urlParams}
 						/>

--- a/frontend/components/artists/artist_show.jsx
+++ b/frontend/components/artists/artist_show.jsx
@@ -17,7 +17,7 @@ const ArtistShow = ({
 	displayArtist,
 	displayAlbum,
 	reduxPlay,
-	toQueueAlbum,
+	toQueueArtist,
 	clearCurrent,
 }) => {
 	useEffect(() => {
@@ -50,7 +50,7 @@ const ArtistShow = ({
 							artistShowRef={artistShowRef}
 							allSongs={allSongs}
 							reduxPlay={reduxPlay}
-							toQueueAlbum={toQueueAlbum}
+							toQueueArtist={toQueueArtist}
 							history={history}
 						/>
 					</div>

--- a/frontend/components/artists/artist_show_container.js
+++ b/frontend/components/artists/artist_show_container.js
@@ -3,7 +3,7 @@ import { displayArtist,
 } from "../../actions/artist_actions";
 import { displayAlbum,
 } from "../../actions/album_actions";
-import { reduxPlay,
+import { toTogglePlay,
     toQueueArtist,
     toPlayArtist,
     toPushPlay,
@@ -31,7 +31,7 @@ const mapStateToProps = (state, ownProps) => {
 const mapDispatchToProps = (dispatch) => ({
     displayArtist: (artistId) => dispatch( displayArtist(artistId) ),
     displayAlbum: (albumId) => dispatch( displayAlbum(albumId) ),
-    reduxPlay: () => dispatch( reduxPlay() ),
+    toTogglePlay: () => dispatch( toTogglePlay() ),
     toQueueArtist: (queueObj) => dispatch( toQueueArtist(queueObj) ),
     toPlayArtist: (queueObj) => dispatch( toPlayArtist(queueObj) ),
     toPushPlay: () => dispatch( toPushPlay() ),

--- a/frontend/components/artists/artist_show_container.js
+++ b/frontend/components/artists/artist_show_container.js
@@ -4,7 +4,7 @@ import { displayArtist,
 import { displayAlbum,
 } from "../../actions/album_actions";
 import { reduxPlay,
-    toQueueAlbum,
+    toQueueArtist,
 } from "../../actions/now_playing_actions";
 
 import { clearCurrent,
@@ -28,7 +28,7 @@ const mapDispatchToProps = (dispatch) => ({
     displayArtist: (artistId) => dispatch( displayArtist(artistId) ),
     displayAlbum: (albumId) => dispatch( displayAlbum(albumId) ),
     reduxPlay: () => dispatch( reduxPlay() ),
-    toQueueAlbum: (songsArray) => dispatch( toQueueAlbum(songsArray) ),
+    toQueueArtist: (songsArray) => dispatch( toQueueArtist(songsArray) ),
     clearCurrent: () => dispatch( clearCurrent() ),
 })
 

--- a/frontend/components/artists/artist_show_container.js
+++ b/frontend/components/artists/artist_show_container.js
@@ -19,8 +19,8 @@ const mapStateToProps = (state, ownProps) => {
         allSongs: state.entities.songs.allSongs,
         collabSongs: state.entities.songs.collabSongs,
         isPlaying: state.entities.nowPlaying.isPlaying,
-        queueSource: state.entities.nowPlaying.queueSource, // = {type:, id:}
-        params: ownProps.params,
+        queueSource: state.entities.nowPlaying.queueSource, // = {sourceType:, urlParams:}
+        urlParams: ownProps.params,
         path: ownProps.path,
         currentUser: ownProps.currentUser,
         history: ownProps.history,
@@ -30,7 +30,7 @@ const mapDispatchToProps = (dispatch) => ({
     displayArtist: (artistId) => dispatch( displayArtist(artistId) ),
     displayAlbum: (albumId) => dispatch( displayAlbum(albumId) ),
     reduxPlay: () => dispatch( reduxPlay() ),
-    toQueueArtist: (songsArray) => dispatch( toQueueArtist(songsArray) ),
+    toQueueArtist: (queueObj) => dispatch( toQueueArtist(queueObj) ),
     clearCurrent: () => dispatch( clearCurrent() ),
 })
 

--- a/frontend/components/artists/artist_show_container.js
+++ b/frontend/components/artists/artist_show_container.js
@@ -18,6 +18,7 @@ const mapStateToProps = (state, ownProps) => {
         albums: state.entities.albums,
         allSongs: state.entities.songs.allSongs,
         collabSongs: state.entities.songs.collabSongs,
+        isPlaying: state.entities.nowPlaying.isPlaying,
         params: ownProps.params,
         path: ownProps.path,
         currentUser: ownProps.currentUser,

--- a/frontend/components/artists/artist_show_container.js
+++ b/frontend/components/artists/artist_show_container.js
@@ -6,6 +6,7 @@ import { displayAlbum,
 import { reduxPlay,
     toQueueArtist,
     toPlayArtist,
+    toPushPlay,
 } from "../../actions/now_playing_actions";
 
 import { clearCurrent,
@@ -33,6 +34,7 @@ const mapDispatchToProps = (dispatch) => ({
     reduxPlay: () => dispatch( reduxPlay() ),
     toQueueArtist: (queueObj) => dispatch( toQueueArtist(queueObj) ),
     toPlayArtist: (queueObj) => dispatch( toPlayArtist(queueObj) ),
+    toPushPlay: () => dispatch( toPushPlay() ),
     clearCurrent: () => dispatch( clearCurrent() ),
 })
 

--- a/frontend/components/artists/artist_show_container.js
+++ b/frontend/components/artists/artist_show_container.js
@@ -5,6 +5,7 @@ import { displayAlbum,
 } from "../../actions/album_actions";
 import { reduxPlay,
     toQueueArtist,
+    toPlayArtist,
 } from "../../actions/now_playing_actions";
 
 import { clearCurrent,
@@ -31,6 +32,7 @@ const mapDispatchToProps = (dispatch) => ({
     displayAlbum: (albumId) => dispatch( displayAlbum(albumId) ),
     reduxPlay: () => dispatch( reduxPlay() ),
     toQueueArtist: (queueObj) => dispatch( toQueueArtist(queueObj) ),
+    toPlayArtist: (queueObj) => dispatch( toPlayArtist(queueObj) ),
     clearCurrent: () => dispatch( clearCurrent() ),
 })
 

--- a/frontend/components/artists/artist_show_container.js
+++ b/frontend/components/artists/artist_show_container.js
@@ -19,6 +19,7 @@ const mapStateToProps = (state, ownProps) => {
         allSongs: state.entities.songs.allSongs,
         collabSongs: state.entities.songs.collabSongs,
         isPlaying: state.entities.nowPlaying.isPlaying,
+        queueSource: state.entities.nowPlaying.queueSource, // = {type:, id:}
         params: ownProps.params,
         path: ownProps.path,
         currentUser: ownProps.currentUser,

--- a/frontend/components/artists/artist_show_container.js
+++ b/frontend/components/artists/artist_show_container.js
@@ -3,6 +3,9 @@ import { displayArtist,
 } from "../../actions/artist_actions";
 import { displayAlbum,
 } from "../../actions/album_actions";
+import { reduxPlay,
+    toQueueAlbum,
+} from "../../actions/now_playing_actions";
 
 import { clearCurrent,
 } from "../../actions/playlist_actions";
@@ -13,6 +16,7 @@ const mapStateToProps = (state, ownProps) => {
     return ({
         currentArtist: state.entities.currentItem,
         albums: state.entities.albums,
+        allSongs: state.entities.songs.allSongs,
         collabSongs: state.entities.songs.collabSongs,
         params: ownProps.params,
         path: ownProps.path,
@@ -23,6 +27,8 @@ const mapStateToProps = (state, ownProps) => {
 const mapDispatchToProps = (dispatch) => ({
     displayArtist: (artistId) => dispatch( displayArtist(artistId) ),
     displayAlbum: (albumId) => dispatch( displayAlbum(albumId) ),
+    reduxPlay: () => dispatch( reduxPlay() ),
+    toQueueAlbum: (songsArray) => dispatch( toQueueAlbum(songsArray) ),
     clearCurrent: () => dispatch( clearCurrent() ),
 })
 

--- a/frontend/components/player/now_playing_info.jsx
+++ b/frontend/components/player/now_playing_info.jsx
@@ -5,7 +5,7 @@ const NowPlayingInfo = ({
 	track,
 	trackProgress,
 	isPlaying,
-	afterFirstPlay,
+	hasQueue,
 	updateTrackProgress,
 }) => {
 	if (!track) {
@@ -22,7 +22,7 @@ const NowPlayingInfo = ({
 	}, [isPlaying]);
 	return (
 		<div className="now-playing">
-			{trackProgress > 0 || (afterFirstPlay && trackProgress === 0) ? (
+			{trackProgress > 0 || (hasQueue && trackProgress === 0) ? (
 				<>
 					<div
 						className="now-playing-art"

--- a/frontend/components/player/player.jsx
+++ b/frontend/components/player/player.jsx
@@ -22,12 +22,27 @@ const Player = ({ tracks, isPlaying, reduxPlay }) => {
 		audioRef.current.src = audioSrc;
 	}, [currentTrack]);
 
+	// Safely play audio only when it is loaded
+
+	const isReady = () => {
+		if (audioRef.current.readyState >= 2) {
+			audioRef.current.play();
+		}
+	};
+	const isReadyListener = () => {
+		audioRef.current.addEventListener("loadeddata", isReady);
+	};
+
 	// Set up play/pause behavior;
 	useEffect(() => {
 		if (isPlaying) {
+			isReadyListener();
 			audioRef.current.play();
 		} else {
 			audioRef.current.pause();
+		}
+		return () => {
+			audioRef.current.removeEventListener("loadeddata", isReady);
 		}
 	}, [isPlaying]);
 

--- a/frontend/components/player/player.jsx
+++ b/frontend/components/player/player.jsx
@@ -2,7 +2,7 @@ import React, { useEffect, useRef, useState } from "react";
 import NowPlayingInfo from "./now_playing_info";
 import PlayingControls from "./playing_controls";
 
-const Player = ({ tracks, isPlaying, reduxPlay }) => {
+const Player = ({ tracks, isPlaying, toTogglePlay }) => {
 	// Set local states
 	const [trackIndex, setTrackIndex] = useState(0);
 	const [trackProgress, setTrackProgress] = useState(0); // progress bar
@@ -98,7 +98,7 @@ const Player = ({ tracks, isPlaying, reduxPlay }) => {
 			/>
 			<PlayingControls
 				isPlaying={isPlaying}
-				togglePlay={reduxPlay}
+				togglePlay={toTogglePlay}
 				toPrevTrack={toPrevTrack}
 				toNextTrack={toNextTrack}
 				toggleShuffle={toggleShuffle}

--- a/frontend/components/player/player.jsx
+++ b/frontend/components/player/player.jsx
@@ -25,7 +25,7 @@ const Player = ({ tracks, isPlaying, reduxPlay }) => {
 	// Safely play audio only when it is loaded
 
 	const isReady = () => {
-		if (audioRef.current.readyState >= 2) {
+		if (audioRef.current.readyState === 4) {
 			audioRef.current.play();
 		}
 	};

--- a/frontend/components/player/player.jsx
+++ b/frontend/components/player/player.jsx
@@ -7,7 +7,6 @@ const Player = ({ tracks, isPlaying, reduxPlay }) => {
 	const [trackIndex, setTrackIndex] = useState(0);
 	const [trackProgress, setTrackProgress] = useState(0); // progress bar
 	const [isShuffling, setIsShuffling] = useState(false);
-	const [afterFirstPlay, setAfterFirstPlay] = useState(false);
 
 	const updateTrackProgress = (time) => {
 		return setTrackProgress(time);
@@ -26,7 +25,6 @@ const Player = ({ tracks, isPlaying, reduxPlay }) => {
 	// Set up play/pause behavior;
 	useEffect(() => {
 		if (isPlaying) {
-			setAfterFirstPlay(true);
 			audioRef.current.play();
 		} else {
 			audioRef.current.pause();
@@ -80,7 +78,7 @@ const Player = ({ tracks, isPlaying, reduxPlay }) => {
 				track={currentTrack}
 				trackProgress={trackProgress}
 				isPlaying={isPlaying}
-				afterFirstPlay={afterFirstPlay}
+				hasQueue={tracks.length > 0}
 				updateTrackProgress={updateTrackProgress}
 			/>
 			<PlayingControls

--- a/frontend/components/player/player.jsx
+++ b/frontend/components/player/player.jsx
@@ -32,7 +32,7 @@ const Player = ({ tracks, isPlaying, reduxPlay }) => {
 			audioRef.current.pause();
 		}
 	}, [isPlaying]);
-	
+
 	// Set up behavior when changing tracks
 	const afterFirstRender = useRef(false); // prevent auto-play
 	useEffect(() => {

--- a/frontend/components/player/player.jsx
+++ b/frontend/components/player/player.jsx
@@ -24,25 +24,25 @@ const Player = ({ tracks, isPlaying, reduxPlay }) => {
 
 	// Safely play audio only when it is loaded
 
-	const isReady = () => {
+	const tryPlay = () => {
 		if (audioRef.current.readyState === 4) {
 			audioRef.current.play();
 		}
 	};
-	const isReadyListener = () => {
-		audioRef.current.addEventListener("loadeddata", isReady);
+	const tryPlayListener = () => {
+		audioRef.current.addEventListener("loadeddata", tryPlay);
 	};
 
 	// Set up play/pause behavior;
 	useEffect(() => {
 		if (isPlaying) {
-			isReadyListener();
+			tryPlayListener();
 			audioRef.current.play();
 		} else {
 			audioRef.current.pause();
 		}
 		return () => {
-			audioRef.current.removeEventListener("loadeddata", isReady);
+			audioRef.current.removeEventListener("loadeddata", tryPlay);
 		}
 	}, [isPlaying]);
 

--- a/frontend/components/player/player_container.js
+++ b/frontend/components/player/player_container.js
@@ -1,7 +1,7 @@
 import { connect } from "react-redux";
 import Player from "./player";
 
-import { reduxPlay } from "../../actions/now_playing_actions";
+import { toTogglePlay } from "../../actions/now_playing_actions";
 
 const mapStateToProps = (state, ownProps) => {
 	return {
@@ -19,7 +19,7 @@ const mapStateToProps = (state, ownProps) => {
 
 const mapDispatchToProps = (dispatch) => ({
 	clearPlaylistErrors: () => dispatch(clearPlaylistErrors()),
-	reduxPlay: () => dispatch(reduxPlay()),
+	toTogglePlay: () => dispatch(toTogglePlay()),
 });
 
 export default connect(mapStateToProps, mapDispatchToProps)(Player);

--- a/frontend/components/player/playing_controls.jsx
+++ b/frontend/components/player/playing_controls.jsx
@@ -1,5 +1,8 @@
 import React from "react";
-import { GrCirclePlay } from "react-icons/gr";
+import {
+	MdOutlinePlayCircleFilled,
+	MdOutlinePauseCircleFilled,
+} from "react-icons/md";
 import { BiSkipPrevious, BiSkipNext, BiShuffle } from "react-icons/bi";
 import { BsRepeat, BsRepeat1, BsPauseCircle } from "react-icons/bs";
 import { useEffect } from "react";
@@ -25,13 +28,13 @@ const PlayingControls = ({
 				onClick={toPrevTrack}
 			/>
 			{isPlaying ? (
-				<BsPauseCircle
+				<MdOutlinePauseCircleFilled
 					className="player__white-icon"
 					aria-label="Pause"
 					onClick={togglePlay}
 				/>
 			) : (
-				<GrCirclePlay
+				<MdOutlinePlayCircleFilled
 					className="player__white-icon"
 					aria-label="Play"
 					onClick={togglePlay}

--- a/frontend/reducers/now_playing_reducer.js
+++ b/frontend/reducers/now_playing_reducer.js
@@ -1,4 +1,4 @@
-import { QUEUE_ALBUM } from "../actions/now_playing_actions";
+import { QUEUE_ARTIST } from "../actions/now_playing_actions";
 import { TOGGLE_PLAY } from "../actions/now_playing_actions";
 
 const nowPlayingReducer = (
@@ -12,7 +12,7 @@ const nowPlayingReducer = (
 			if (newPlayState.queue?.length > 0)
 				newPlayState.isPlaying = !newPlayState.isPlaying;
 			return newPlayState;
-		case QUEUE_ALBUM: // payload is an array of song objects
+		case QUEUE_ARTIST: // payload is an array of song objects
 			newPlayState.queue.push(...action.songs);
 		default:
 			return playState;

--- a/frontend/reducers/now_playing_reducer.js
+++ b/frontend/reducers/now_playing_reducer.js
@@ -23,6 +23,10 @@ const nowPlayingReducer = (
 				sourceType: action.sourceType,
 				extractedUrlParams: action.extractedUrlParams,
 			};
+			// TODO: Add code for queue to track multiple queueSources
+			// for each series of songs added
+			// TODO: Consider separate key to hold current track 
+			// to continue playback for when user clears the queue
 			return newPlayState;
 		default:
 			return playState;

--- a/frontend/reducers/now_playing_reducer.js
+++ b/frontend/reducers/now_playing_reducer.js
@@ -5,7 +5,7 @@ const nowPlayingReducer = (
 	playState = {
 		isPlaying: false,
 		queue: [],
-		queueSource: { type: null, id: null },
+		queueSource: { sourceType: null, extractedUrlParams: null },
 	},
 	action
 ) => {
@@ -16,10 +16,14 @@ const nowPlayingReducer = (
 			if (newPlayState.queue?.length > 0)
 				newPlayState.isPlaying = !newPlayState.isPlaying;
 			return newPlayState;
-		case QUEUE_ARTIST: // payload is an array of song objects
-			newPlayState.queue.push(...action.songs);
+		case QUEUE_ARTIST:
+			newPlayState.queue.push(...action.allSongs);
 			// mutate the object so the player does not stop playing to re-render
-			newPlayState.queueSource = { type: artist, id: action.urlParams };
+			newPlayState.queueSource = {
+				sourceType: action.sourceType,
+				extractedUrlParams: action.extractedUrlParams,
+			};
+			return newPlayState;
 		default:
 			return playState;
 	}

--- a/frontend/reducers/now_playing_reducer.js
+++ b/frontend/reducers/now_playing_reducer.js
@@ -1,4 +1,4 @@
-import { QUEUE_ARTIST, PLAY_ARTIST } from "../actions/now_playing_actions";
+import { QUEUE_ARTIST, PLAY_ARTIST, PUSH_PLAY } from "../actions/now_playing_actions";
 import { TOGGLE_PLAY } from "../actions/now_playing_actions";
 
 const nowPlayingReducer = (
@@ -15,6 +15,9 @@ const nowPlayingReducer = (
 		case TOGGLE_PLAY:
 			if (newPlayState.queue?.length > 0)
 				newPlayState.isPlaying = !newPlayState.isPlaying;
+			return newPlayState;
+		case PUSH_PLAY:
+			if (newPlayState.queue?.length > 0) newPlayState.isPlaying = true;
 			return newPlayState;
 		case QUEUE_ARTIST:
 			newPlayState.queue.push(...action.allSongs);

--- a/frontend/reducers/now_playing_reducer.js
+++ b/frontend/reducers/now_playing_reducer.js
@@ -1,4 +1,4 @@
-import { RECEIVE_CURRENT_ARTIST } from "../actions/artist_actions";
+import { QUEUE_ALBUM } from "../actions/now_playing_actions";
 import { TOGGLE_PLAY } from "../actions/now_playing_actions";
 
 const nowPlayingReducer = (
@@ -8,13 +8,15 @@ const nowPlayingReducer = (
 	Object.freeze(playState);
 	let newPlayState = Object.assign({}, playState);
 	switch (action.type) {
-		case RECEIVE_CURRENT_ARTIST:
-			newPlayState.queue = [...action.allSongs];
-			return newPlayState;
 		case TOGGLE_PLAY:
 			if (newPlayState.queue?.length > 0)
 				newPlayState.isPlaying = !newPlayState.isPlaying;
 			return newPlayState;
+		case QUEUE_ALBUM: // payload is an array of song objects
+			action.songs.forEach((song) => {
+				newPlayState.queue.push(song);
+				console.log("newPlayState.queue", newPlayState.queue)
+			});
 		default:
 			return playState;
 	}

--- a/frontend/reducers/now_playing_reducer.js
+++ b/frontend/reducers/now_playing_reducer.js
@@ -1,5 +1,4 @@
-import { QUEUE_ARTIST,
-PLAY_ARTIST } from "../actions/now_playing_actions";
+import { QUEUE_ARTIST, PLAY_ARTIST } from "../actions/now_playing_actions";
 import { TOGGLE_PLAY } from "../actions/now_playing_actions";
 
 const nowPlayingReducer = (
@@ -28,15 +27,16 @@ const nowPlayingReducer = (
 			// for each series of songs added
 			// TODO: Consider separate key to hold current track
 			// to continue playback for when user clears the queue
+			console.log("NEW QUEUE", newPlayState.queue);
 			return newPlayState;
 		case PLAY_ARTIST:
-			debugger
 			newPlayState.queue = action.allSongs;
 			// replace the entire queue
 			newPlayState.queueSource = {
 				sourceType: action.sourceType,
 				extractedUrlParams: action.extractedUrlParams,
 			};
+			console.log("NEW QUEUE", newPlayState.queue);
 			return newPlayState;
 		default:
 			return playState;

--- a/frontend/reducers/now_playing_reducer.js
+++ b/frontend/reducers/now_playing_reducer.js
@@ -2,7 +2,11 @@ import { QUEUE_ARTIST } from "../actions/now_playing_actions";
 import { TOGGLE_PLAY } from "../actions/now_playing_actions";
 
 const nowPlayingReducer = (
-	playState = { isPlaying: false, queue: [] },
+	playState = {
+		isPlaying: false,
+		queue: [],
+		queueSource: { type: null, id: null },
+	},
 	action
 ) => {
 	Object.freeze(playState);
@@ -14,6 +18,8 @@ const nowPlayingReducer = (
 			return newPlayState;
 		case QUEUE_ARTIST: // payload is an array of song objects
 			newPlayState.queue.push(...action.songs);
+			// mutate the object so the player does not stop playing to re-render
+			newPlayState.queueSource = { type: artist, id: action.urlParams };
 		default:
 			return playState;
 	}

--- a/frontend/reducers/now_playing_reducer.js
+++ b/frontend/reducers/now_playing_reducer.js
@@ -1,4 +1,5 @@
-import { QUEUE_ARTIST } from "../actions/now_playing_actions";
+import { QUEUE_ARTIST,
+PLAY_ARTIST } from "../actions/now_playing_actions";
 import { TOGGLE_PLAY } from "../actions/now_playing_actions";
 
 const nowPlayingReducer = (
@@ -25,8 +26,17 @@ const nowPlayingReducer = (
 			};
 			// TODO: Add code for queue to track multiple queueSources
 			// for each series of songs added
-			// TODO: Consider separate key to hold current track 
+			// TODO: Consider separate key to hold current track
 			// to continue playback for when user clears the queue
+			return newPlayState;
+		case PLAY_ARTIST:
+			debugger
+			newPlayState.queue = action.allSongs;
+			// replace the entire queue
+			newPlayState.queueSource = {
+				sourceType: action.sourceType,
+				extractedUrlParams: action.extractedUrlParams,
+			};
 			return newPlayState;
 		default:
 			return playState;

--- a/frontend/reducers/now_playing_reducer.js
+++ b/frontend/reducers/now_playing_reducer.js
@@ -13,10 +13,7 @@ const nowPlayingReducer = (
 				newPlayState.isPlaying = !newPlayState.isPlaying;
 			return newPlayState;
 		case QUEUE_ALBUM: // payload is an array of song objects
-			action.songs.forEach((song) => {
-				newPlayState.queue.push(song);
-				console.log("newPlayState.queue", newPlayState.queue)
-			});
+			newPlayState.queue.push(...action.songs);
 		default:
 			return playState;
 	}


### PR DESCRIPTION
Fixes bug (TODO 2/2.5 from #94) where queue and playback would reset when going from one ArtistShow Page to another.
Fixes bug where pressing Play button on ArtistShow page would re-queue the songs instead of pausing.
Fixes bug where pressing Play on another artist's page during playback would error out since playback was occurring before audio file was ready.
Fixes bug where ArtistPageDropdown wouldn't close automatically after choosing an option.
Fixes misnaming where Artist Redux actions were named after Albums.

Expanded NowPlaying Redux actions so to fully uncouple the queue from the current Artist view (TODO 1 from #96).
Play button on ArtistPageMenuBar is now fully functional.
Play button on ArtistShow page now shows pause if current view matches what is currently playing.
"Add to queue" dropdown option now adds artist's songs to NowPlaying queue.
Standardizes react-icons used in ArtistShow and in Player.

Resources:
- [HTMLMediaElement, readyState](https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/readyState)

<hr>

TODO:
- [ ] 1) Extract queueObj and queueSource comparison to reducer, not component
- [ ] 2) Add a way to store multiple queueSources in the Redux queue so that only one specific view shows Pause button when browsing
- [ ] 3) Create a view for the user to view/access the queue
- [ ] 4) Create a progress bar for track progress and seeking
- [ ] 5) NEEDS FIX: nextTrack and previousTrack functionalities sometimes don't work.
- [ ] 6) NEEDS FIX: Randomly generated monthly listeners on ArtistShow page refreshes with every play/pause.

### Result (play with sound)
https://github.com/imartinez921/versify_full-stack/assets/102888592/86abad75-2fc4-4468-9f0f-0d5f397d68a7