### PR TITLE
Refine queueSources and objToQueue

### DIFF
--- a/frontend/actions/now_playing_actions.js
+++ b/frontend/actions/now_playing_actions.js
@@ -11,30 +11,30 @@ const pushPlay = () => ({
 	type: PUSH_PLAY,
 });
 
-const queueArtist = (queueObj) => ({
+const queueArtist = (objToQueue) => ({
 	//{allSongs:arr, sourceType:str, extractedUrlParams:numStr}
 	type: QUEUE_ARTIST,
-	allSongs: queueObj.allSongs,
-	sourceType: queueObj.sourceType,
-	extractedUrlParams: queueObj.extractedUrlParams,
+	allSongs: objToQueue.allSongs,
+	sourceType: objToQueue.sourceType,
+	extractedUrlParams: objToQueue.extractedUrlParams,
 });
 
-const playArtist = (queueObj) => ({
+const playArtist = (objToQueue) => ({
 	//{allSongs:arr, sourceType:str, extractedUrlParams:numStr}
 	type: PLAY_ARTIST,
-	allSongs: queueObj.allSongs,
-	sourceType: queueObj.sourceType,
-	extractedUrlParams: queueObj.extractedUrlParams,
+	allSongs: objToQueue.allSongs,
+	sourceType: objToQueue.sourceType,
+	extractedUrlParams: objToQueue.extractedUrlParams,
 });
 
 export const toTogglePlay = () => (dispatch) => dispatch(togglePlay());
 
-export const toQueueArtist = (queueObj) => (dispatch) => {
-	return dispatch(queueArtist(queueObj));
+export const toQueueArtist = (objToQueue) => (dispatch) => {
+	return dispatch(queueArtist(objToQueue));
 };
 
-export const toPlayArtist = (queueObj) => (dispatch) => {
-	return dispatch(playArtist(queueObj));
+export const toPlayArtist = (objToQueue) => (dispatch) => {
+	return dispatch(playArtist(objToQueue));
 };
 
-export const toPushPlay = () => (dispatch) => dispatch(pushPlay())
+export const toPushPlay = () => (dispatch) => dispatch(pushPlay());

--- a/frontend/actions/playlist_actions.js
+++ b/frontend/actions/playlist_actions.js
@@ -35,10 +35,11 @@ export const createPlaylist = (defaultPlaylist) => (dispatch) => {
 };
 
 export const displayPlaylist = (playlistId) => (dispatch) => {
+    debugger
     return showPlaylist(playlistId).then(
         (playlist) => dispatch(receiveCurrentPlaylist(playlist)),
-        (err) => dispatch(receivePlaylistErrors(err.responseJSON))
-    );
+        // (err) => dispatch(receivePlaylistErrors(err.responseJSON))
+        (err) => console.log(err))
     // err => (console.log(err)) )
 };
 

--- a/frontend/components/artists/artist_page_dropdown_container.js
+++ b/frontend/components/artists/artist_page_dropdown_container.js
@@ -36,7 +36,9 @@ const mapStateToProps = (state, ownProps) => {
 };
 
 const mapDispatchToProps = (dispatch) => ({
-	toQueueArtist: (queueObj) => dispatch(toQueueArtist(queueObj)),
+	toQueueArtist: (objToQueue) => dispatch(toQueueArtist(objToQueue)),
 });
 
-export default connect(mapStateToProps, mapDispatchToProps, null, {forwardRef: true})(ArtistPageDropdown);
+export default connect(mapStateToProps, mapDispatchToProps, null, {
+	forwardRef: true,
+})(ArtistPageDropdown);

--- a/frontend/components/artists/artist_page_menu_bar.jsx
+++ b/frontend/components/artists/artist_page_menu_bar.jsx
@@ -11,7 +11,7 @@ const ArtistPageMenuBar = ({
 	artistShowRef,
 	allSongs,
 	isPlaying,
-	queueSource,
+	currentQueueSource,
 	toTogglePlay,
 	toQueueArtist,
 	toPlayArtist,
@@ -45,8 +45,9 @@ const ArtistPageMenuBar = ({
 	const handleButtonClick = (e) => {
 		e.preventDefault();
 		if (
-			queueObj.sourceType === queueSource.sourceType &&
-			queueObj.extractedUrlParams === queueSource.extractedUrlParams
+			!!currentQueueSource &&
+			queueObj.sourceType === currentQueueSource.sourceType &&
+			queueObj.extractedUrlParams === currentQueueSource.extractedUrlParams
 		) {
 			toTogglePlay();
 		} else {
@@ -67,9 +68,9 @@ const ArtistPageMenuBar = ({
 		<>
 			<div id="artist-play-button" onClick={handleButtonClick}>
 				{isPlaying &&
-				queueObj.sourceType === queueSource.sourceType &&
+				queueObj.sourceType === currentQueueSource.sourceType &&
 				queueObj.extractedUrlParams ===
-					queueSource.extractedUrlParams ? (
+					currentQueueSource.extractedUrlParams ? (
 					<MdOutlinePauseCircleFilled />
 				) : (
 					<MdOutlinePlayCircleFilled />

--- a/frontend/components/artists/artist_page_menu_bar.jsx
+++ b/frontend/components/artists/artist_page_menu_bar.jsx
@@ -35,7 +35,7 @@ const ArtistPageMenuBar = ({
 		}
 	}
 
-	const queueObj = {
+	const objToQueue = {
 		allSongs,
 		sourceType: "artist",
 		extractedUrlParams: urlParams.id,
@@ -46,19 +46,19 @@ const ArtistPageMenuBar = ({
 		e.preventDefault();
 		if (
 			!!currentQueueSource &&
-			queueObj.sourceType === currentQueueSource.sourceType &&
-			queueObj.extractedUrlParams === currentQueueSource.extractedUrlParams
+			objToQueue.sourceType === currentQueueSource.sourceType &&
+			objToQueue.extractedUrlParams === currentQueueSource.extractedUrlParams
 		) {
 			toTogglePlay();
 		} else {
-			toPlayArtist(queueObj);
+			toPlayArtist(objToQueue);
 			toPushPlay();
 		}
 	};
 
 	const handleAddToQueue = (e) => {
 		e.preventDefault();
-		toQueueArtist(queueObj);
+		toQueueArtist(objToQueue);
 		setArtistPageDropdownState({ isOpen: false });
 	};
 
@@ -68,8 +68,8 @@ const ArtistPageMenuBar = ({
 		<>
 			<div id="artist-play-button" onClick={handleButtonClick}>
 				{isPlaying &&
-				queueObj.sourceType === currentQueueSource.sourceType &&
-				queueObj.extractedUrlParams ===
+				objToQueue.sourceType === currentQueueSource.sourceType &&
+				objToQueue.extractedUrlParams ===
 					currentQueueSource.extractedUrlParams ? (
 					<MdOutlinePauseCircleFilled />
 				) : (

--- a/frontend/components/artists/artist_show.jsx
+++ b/frontend/components/artists/artist_show.jsx
@@ -11,7 +11,7 @@ const ArtistShow = ({
 	allSongs,
 	collabSongs,
 	isPlaying,
-	queueSource,
+	currentQueueSource,
 	urlParams,
 	path,
 	currentUser,
@@ -54,7 +54,7 @@ const ArtistShow = ({
 							artistShowRef={artistShowRef}
 							allSongs={allSongs}
 							isPlaying={isPlaying}
-							queueSource={queueSource}
+							currentQueueSource={currentQueueSource}
 							toTogglePlay={toTogglePlay}
 							toQueueArtist={toQueueArtist}
 							toPlayArtist={toPlayArtist}

--- a/frontend/components/artists/artist_show_container.js
+++ b/frontend/components/artists/artist_show_container.js
@@ -31,8 +31,8 @@ const mapDispatchToProps = (dispatch) => ({
 	displayArtist: (artistId) => dispatch(displayArtist(artistId)),
 	displayAlbum: (albumId) => dispatch(displayAlbum(albumId)),
 	toTogglePlay: () => dispatch(toTogglePlay()),
-	toQueueArtist: (queueObj) => dispatch(toQueueArtist(queueObj)),
-	toPlayArtist: (queueObj) => dispatch(toPlayArtist(queueObj)),
+	toQueueArtist: (objToQueue) => dispatch(toQueueArtist(objToQueue)),
+	toPlayArtist: (objToQueue) => dispatch(toPlayArtist(objToQueue)),
 	toPushPlay: () => dispatch(toPushPlay()),
 	clearCurrent: () => dispatch(clearCurrent()),
 });

--- a/frontend/components/artists/artist_show_container.js
+++ b/frontend/components/artists/artist_show_container.js
@@ -1,41 +1,40 @@
 import { connect } from "react-redux";
-import { displayArtist,
-} from "../../actions/artist_actions";
-import { displayAlbum,
-} from "../../actions/album_actions";
-import { toTogglePlay,
-    toQueueArtist,
-    toPlayArtist,
-    toPushPlay,
+import { displayArtist } from "../../actions/artist_actions";
+import { displayAlbum } from "../../actions/album_actions";
+import {
+	toTogglePlay,
+	toQueueArtist,
+	toPlayArtist,
+	toPushPlay,
 } from "../../actions/now_playing_actions";
 
-import { clearCurrent,
-} from "../../actions/playlist_actions";
+import { clearCurrent } from "../../actions/playlist_actions";
 
 import ArtistShow from "./artist_show";
 
 const mapStateToProps = (state, ownProps) => {
-    return ({
-        currentArtist: state.entities.currentItem,
-        albums: state.entities.albums,
-        allSongs: state.entities.songs.allSongs,
-        collabSongs: state.entities.songs.collabSongs,
-        isPlaying: state.entities.nowPlaying.isPlaying,
-        queueSource: state.entities.nowPlaying.queueSource, // = {sourceType:, urlParams:}
-        urlParams: ownProps.params,
-        path: ownProps.path,
-        currentUser: ownProps.currentUser,
-        history: ownProps.history,
-})}
+	return {
+		currentArtist: state.entities.currentItem,
+		albums: state.entities.albums,
+		allSongs: state.entities.songs.allSongs,
+		collabSongs: state.entities.songs.collabSongs,
+		isPlaying: state.entities.nowPlaying.isPlaying,
+		currentQueueSource: state.entities.nowPlaying.queueSources[0], // = {sourceType:, urlParams:}
+		urlParams: ownProps.params,
+		path: ownProps.path,
+		currentUser: ownProps.currentUser,
+		history: ownProps.history,
+	};
+};
 
 const mapDispatchToProps = (dispatch) => ({
-    displayArtist: (artistId) => dispatch( displayArtist(artistId) ),
-    displayAlbum: (albumId) => dispatch( displayAlbum(albumId) ),
-    toTogglePlay: () => dispatch( toTogglePlay() ),
-    toQueueArtist: (queueObj) => dispatch( toQueueArtist(queueObj) ),
-    toPlayArtist: (queueObj) => dispatch( toPlayArtist(queueObj) ),
-    toPushPlay: () => dispatch( toPushPlay() ),
-    clearCurrent: () => dispatch( clearCurrent() ),
-})
+	displayArtist: (artistId) => dispatch(displayArtist(artistId)),
+	displayAlbum: (albumId) => dispatch(displayAlbum(albumId)),
+	toTogglePlay: () => dispatch(toTogglePlay()),
+	toQueueArtist: (queueObj) => dispatch(toQueueArtist(queueObj)),
+	toPlayArtist: (queueObj) => dispatch(toPlayArtist(queueObj)),
+	toPushPlay: () => dispatch(toPushPlay()),
+	clearCurrent: () => dispatch(clearCurrent()),
+});
 
 export default connect(mapStateToProps, mapDispatchToProps)(ArtistShow);

--- a/frontend/components/player/now_playing_info.jsx
+++ b/frontend/components/player/now_playing_info.jsx
@@ -4,8 +4,8 @@ const NowPlayingInfo = ({
 	audioRef,
 	track,
 	trackProgress,
+	length, // Refreshes component whenever queue changes
 	isPlaying,
-	hasQueue,
 	updateTrackProgress,
 }) => {
 	if (!track) {
@@ -22,7 +22,7 @@ const NowPlayingInfo = ({
 	}, [isPlaying]);
 	return (
 		<div className="now-playing">
-			{trackProgress > 0 || (hasQueue && trackProgress === 0) ? (
+			{!!track.title ? (
 				<>
 					<div
 						className="now-playing-art"

--- a/frontend/components/player/player.jsx
+++ b/frontend/components/player/player.jsx
@@ -93,7 +93,6 @@ const Player = ({ tracks, isPlaying, toTogglePlay }) => {
 				track={currentTrack}
 				trackProgress={trackProgress}
 				isPlaying={isPlaying}
-				hasQueue={tracks.length > 0}
 				updateTrackProgress={updateTrackProgress}
 			/>
 			<PlayingControls

--- a/frontend/components/player/player_container.js
+++ b/frontend/components/player/player_container.js
@@ -13,6 +13,7 @@ const mapStateToProps = (state, ownProps) => {
 		path: ownProps.path,
 		history: ownProps.history,
 		tracks: state.entities.nowPlaying.queue,
+		length: state.entities.nowPlaying.queue.length,
 		isPlaying: state.entities.nowPlaying.isPlaying,
 	};
 };

--- a/frontend/components/player/playing_controls.jsx
+++ b/frontend/components/player/playing_controls.jsx
@@ -17,7 +17,8 @@ const PlayingControls = ({
 }) => {
 	return (
 		<div className="playing-controls">
-			<BiShuffle
+			{/* <BiShuffle/ */}
+			<div
 				className="player__grey-icon repeat-shuffle-icon"
 				aria-label="Shuffle"
 				onClick={toggleShuffle}
@@ -45,7 +46,8 @@ const PlayingControls = ({
 				aria-label="Next"
 				onClick={toNextTrack}
 			/>
-			<BsRepeat // TODO: implement repeat functionality
+			{/* <BsRepeat // TODO: implement repeat functionality */}
+			<div
 				className="player__grey-icon repeat-shuffle-icon"
 				aria-label="Repeat"
 			/>

--- a/frontend/reducers/now_playing_reducer.js
+++ b/frontend/reducers/now_playing_reducer.js
@@ -1,11 +1,15 @@
-import { QUEUE_ARTIST, PLAY_ARTIST, PUSH_PLAY } from "../actions/now_playing_actions";
+import {
+	QUEUE_ARTIST,
+	PLAY_ARTIST,
+	PUSH_PLAY,
+} from "../actions/now_playing_actions";
 import { TOGGLE_PLAY } from "../actions/now_playing_actions";
 
 const nowPlayingReducer = (
 	playState = {
 		isPlaying: false,
 		queue: [],
-		queueSource: { sourceType: null, extractedUrlParams: null },
+		queueSources: [],
 	},
 	action
 ) => {
@@ -20,30 +24,33 @@ const nowPlayingReducer = (
 			if (newPlayState.queue?.length > 0) newPlayState.isPlaying = true;
 			return newPlayState;
 		case QUEUE_ARTIST:
+			// Mutate the object so any currently playing track is not disrupted
 			newPlayState.queue.push(...action.allSongs);
-			// mutate the object so the player does not stop playing to re-render
-			newPlayState.queueSource = {
-				sourceType: action.sourceType,
-				extractedUrlParams: action.extractedUrlParams,
-			};
-			// TODO: Add code for queue to track multiple queueSources
-			// for each series of songs added
+			// Track the origin view of each song in the queue
+			for (let i = 0; i < action.allSongs.length; i++) {
+				newPlayState.queueSources.push({
+					sourceType: action.sourceType,
+					extractedUrlParams: action.extractedUrlParams,
+				});
+			}
 			// TODO: Consider separate key to hold current track
 			// to continue playback for when user clears the queue
 			console.log("NEW QUEUE", newPlayState.queue);
 			return newPlayState;
 		case PLAY_ARTIST:
-			newPlayState.queue = action.allSongs;
-			// replace the entire queue
-			newPlayState.queueSource = {
-				sourceType: action.sourceType,
-				extractedUrlParams: action.extractedUrlParams,
-			};
+			newPlayState.queue = action.allSongs; // Replace the entire queue
+			newPlayState.queueSources=[]; // Reset queueSources for new queue
+			for (let i = 0; i < action.allSongs.length; i++) {
+				newPlayState.queueSources.push({
+					sourceType: action.sourceType,
+					extractedUrlParams: action.extractedUrlParams,
+				});
+			}
 			console.log("NEW QUEUE", newPlayState.queue);
 			return newPlayState;
-		default:
-			return playState;
-	}
+			default:
+				return playState;
+		}
 };
 
 export default nowPlayingReducer;


### PR DESCRIPTION
Adds support for multiple queueSources (TODO 2 from #97).
Changes variable name queueObj to objToQueue for clarity.
Hides shuffle/repeat buttons until functionality is completed.
Adds logging to console for occasional error upon fetching playlist#show

<hr> 

TODO:
- [ ] 1) NEEDS FIX: currentQueueSource does not change index to match currentTrack when changing to next/previous track 
- [ ] 2) NEEDS FIX: Occasional nil class error on `current_user.id` upon login and first fetching for Playlist#show
- [ ] 3) Add Suspense for fallback loading mechanisms and error catching
   - [ ] Have ArtistIndex be last priority to load
- [ ]  4) Add eventListener for when a track ends
   - [ ]  When track ends, play next track
   - [ ]  When track ends, change pause button to new currentQueueSource