### PR TITLE
Allow player to play any Show view (PlaylistShow, ArtistShow, AlbumShow)

### DIFF
--- a/frontend/actions/now_playing_actions.js
+++ b/frontend/actions/now_playing_actions.js
@@ -4,6 +4,7 @@ export const QUEUE_ARTIST = "QUEUE_ARTIST";
 export const PLAY_ARTIST = "PLAY_ARTIST";
 export const QUEUE_PLAYLIST = "QUEUE_PLAYLIST";
 export const PLAY_PLAYLIST = "PLAY_PLAYLIST";
+export const PLAY_VIEW = "PLAY_VIEW";
 
 const togglePlay = () => ({
 	type: TOGGLE_PLAY,
@@ -45,6 +46,15 @@ const playPlaylist = (objToQueue) => ({
 	extractedUrlParams: objToQueue.extractedUrlParams,
 });
 
+const playView = (objToQueue) => {
+	return {
+	//{viewSongs:arr, sourceType:str, extractedUrlParams:numStr}
+	type: PLAY_VIEW,
+	songs: objToQueue.viewSongs,
+	sourceType: objToQueue.sourceType,
+	extractedUrlParams: objToQueue.extractedUrlParams,
+}};
+
 export const toTogglePlay = () => (dispatch) => dispatch(togglePlay());
 
 export const toQueueArtist = (objToQueue) => (dispatch) => {
@@ -55,12 +65,16 @@ export const toPlayArtist = (objToQueue) => (dispatch) => {
 	return dispatch(playArtist(objToQueue));
 };
 
+export const toPlayPlaylist = (objToQueue) => (dispatch) => {
+	return dispatch(playPlaylist(objToQueue));
+};
+
 export const toQueuePlaylist = (objToQueue) => (dispatch) => {
 	return dispatch(queuePlaylist(objToQueue));
 };
 
-export const toPlayPlaylist = (objToQueue) => (dispatch) => {
-	return dispatch(playPlaylist(objToQueue));
+export const toPlayView = (objToQueue) => (dispatch) => {
+	return dispatch(playView(objToQueue));
 };
 
 export const toPushPlay = () => (dispatch) => dispatch(pushPlay());

--- a/frontend/components/page/page.jsx
+++ b/frontend/components/page/page.jsx
@@ -12,7 +12,6 @@ const Page = ({
 	currentUser,
 	errors,
 	clearPlaylistErrors,
-	tracks,
 }) => {
 	return (
 		<div className="page-container">

--- a/frontend/components/page/page_container.js
+++ b/frontend/components/page/page_container.js
@@ -8,6 +8,7 @@ const mapStateToProps = (state, ownProps) => ({
 	// matchObj is a prop passed down by AuthRoute
 	params: ownProps.match.params,
 	path: ownProps.match.path,
+	// history is also a prop passed down by AuthRoute
 	history: ownProps.history,
 });
 

--- a/frontend/components/player/player.jsx
+++ b/frontend/components/player/player.jsx
@@ -2,7 +2,16 @@ import React, { useEffect, useRef, useState } from "react";
 import NowPlayingInfo from "./now_playing_info";
 import PlayingControls from "./playing_controls";
 
-const Player = ({ tracks, isPlaying, toTogglePlay }) => {
+const Player = ({
+	pathname,
+	tracks,
+	songs,
+	isPlaying,
+	hasQueue,
+	toPlayView,
+	toTogglePlay,
+	toPushPlay,
+}) => {
 	// Set local states
 	const [trackIndex, setTrackIndex] = useState(0);
 	const [trackProgress, setTrackProgress] = useState(0); // progress bar
@@ -43,7 +52,7 @@ const Player = ({ tracks, isPlaying, toTogglePlay }) => {
 		}
 		return () => {
 			audioRef.current.removeEventListener("loadeddata", tryPlay);
-		}
+		};
 	}, [isPlaying]);
 
 	// Set up behavior when changing tracks
@@ -86,6 +95,14 @@ const Player = ({ tracks, isPlaying, toTogglePlay }) => {
 		}
 	};
 
+	const sourceType = pathname.split("/")[1];
+	const extractedUrlParams = pathname.split("/")[2];
+	const objToQueue = {
+		viewSongs: songs,
+		sourceType,
+		extractedUrlParams,
+	}; // provides linkback to view currently playing
+
 	return (
 		<div className="player-container">
 			<NowPlayingInfo
@@ -96,8 +113,12 @@ const Player = ({ tracks, isPlaying, toTogglePlay }) => {
 				updateTrackProgress={updateTrackProgress}
 			/>
 			<PlayingControls
+				hasQueue={hasQueue}
+				objToQueue={objToQueue}
 				isPlaying={isPlaying}
+				toPlayView={toPlayView}
 				togglePlay={toTogglePlay}
+				toPushPlay={toPushPlay}
 				toPrevTrack={toPrevTrack}
 				toNextTrack={toNextTrack}
 				toggleShuffle={toggleShuffle}

--- a/frontend/components/player/player_container.js
+++ b/frontend/components/player/player_container.js
@@ -9,7 +9,6 @@ const mapStateToProps = (state, ownProps) => {
 		errors: state.entities.errors,
 		// matchObj is a prop passed down by AuthRoute
 		// matchObj = {params, path, url} as keys
-		params: ownProps.params,
 		path: ownProps.path,
 		history: ownProps.history,
 		tracks: state.entities.nowPlaying.queue,

--- a/frontend/components/player/player_container.js
+++ b/frontend/components/player/player_container.js
@@ -1,25 +1,31 @@
 import { connect } from "react-redux";
 import Player from "./player";
 
-import { toTogglePlay } from "../../actions/now_playing_actions";
+import {
+	toPlayView,
+	toTogglePlay,
+	toPushPlay,
+} from "../../actions/now_playing_actions";
 
 const mapStateToProps = (state, ownProps) => {
 	return {
 		currentUser: state.entities.users[state.session.id],
 		errors: state.entities.errors,
+		tracks: state.entities.nowPlaying.queue,
+		songs: state.entities.songs, // songs of the current view
+		isPlaying: state.entities.nowPlaying.isPlaying,
+		hasQueue: state.entities.nowPlaying.queue.length > 0,
 		// matchObj is a prop passed down by AuthRoute
 		// matchObj = {params, path, url} as keys
-		path: ownProps.path,
-		history: ownProps.history,
-		tracks: state.entities.nowPlaying.queue,
-		length: state.entities.nowPlaying.queue.length,
-		isPlaying: state.entities.nowPlaying.isPlaying,
+		pathname: ownProps.history.location.pathname,
 	};
 };
 
 const mapDispatchToProps = (dispatch) => ({
 	clearPlaylistErrors: () => dispatch(clearPlaylistErrors()),
+	toPlayView: (objToQueue) => dispatch(toPlayView(objToQueue)),
 	toTogglePlay: () => dispatch(toTogglePlay()),
+	toPushPlay: () => dispatch(toPushPlay()),
 });
 
 export default connect(mapStateToProps, mapDispatchToProps)(Player);

--- a/frontend/components/player/playing_controls.jsx
+++ b/frontend/components/player/playing_controls.jsx
@@ -18,7 +18,6 @@ const PlayingControls = ({
 	toNextTrack,
 	toggleShuffle,
 }) => {
-	console.log(objToQueue);
 
 	const handleClick = (e) => {
 		e.preventDefault();

--- a/frontend/components/player/playing_controls.jsx
+++ b/frontend/components/player/playing_controls.jsx
@@ -8,13 +8,32 @@ import { BsRepeat, BsRepeat1, BsPauseCircle } from "react-icons/bs";
 import { useEffect } from "react";
 
 const PlayingControls = ({
+	hasQueue,
+	objToQueue,
 	isPlaying,
-	trackProgress,
+	toPlayView,
 	togglePlay,
+	toPushPlay,
 	toPrevTrack,
 	toNextTrack,
 	toggleShuffle,
 }) => {
+	console.log(objToQueue);
+
+	const handleClick = (e) => {
+		e.preventDefault();
+		if (objToQueue.sourceType === "artist") {
+			// Accounts for unique currentItem slice of state when ArtistShow view
+			objToQueue.viewSongs = objToQueue.viewSongs.allSongs;
+		}
+		if (!hasQueue) {
+			toPlayView(objToQueue);
+			toPushPlay();
+		} else {
+			togglePlay();
+		}
+	};
+
 	return (
 		<div className="playing-controls">
 			{/* <BiShuffle/ */}
@@ -38,7 +57,7 @@ const PlayingControls = ({
 				<MdOutlinePlayCircleFilled
 					className="player__white-icon"
 					aria-label="Play"
-					onClick={togglePlay}
+					onClick={handleClick}
 				/>
 			)}
 			<BiSkipNext

--- a/frontend/reducers/current_item_reducer.js
+++ b/frontend/reducers/current_item_reducer.js
@@ -14,12 +14,15 @@ const currentItemReducer = (currItemState = {}, action) => {
     switch (action.type) {
         case RECEIVE_CURRENT_PLAYLIST:
             let currPlaylist = action.playlist;
+            currPlaylist['source'] = "playlist";
             return currPlaylist;
         case RECEIVE_CURRENT_ARTIST:
             let currArtist = action.artist;
+            currArtist['source'] = "artist";
             return currArtist;
         case RECEIVE_CURRENT_ALBUM:
             let currAlbum = action.album;
+            currAlbum['source'] = "album";
             return currAlbum;
         case RESET_CURRENT:
             return {};

--- a/frontend/reducers/now_playing_reducer.js
+++ b/frontend/reducers/now_playing_reducer.js
@@ -4,6 +4,7 @@ import {
 	QUEUE_PLAYLIST,
 	PLAY_PLAYLIST,
 	PUSH_PLAY,
+	PLAY_VIEW,
 } from "../actions/now_playing_actions";
 import { TOGGLE_PLAY } from "../actions/now_playing_actions";
 
@@ -21,7 +22,7 @@ const nowPlayingReducer = (
 		queue: [...playState.queue],
 		queueSources: [...playState.queueSources],
 	}
-	// Rectifies issues with shallow copies where nested objs kept the same refs
+	// Above rectifies issues with shallow copies where nested objs kept the same refs
 	switch (action.type) {
 		case TOGGLE_PLAY:
 			if (newPlayState.queue?.length > 0)
@@ -47,15 +48,16 @@ const nowPlayingReducer = (
 			return newPlayState;
 		case PLAY_ARTIST:
 		case PLAY_PLAYLIST:
+		case PLAY_VIEW:
 			newPlayState.queue = action.songs; // Replace the entire queue
 			newPlayState.queueSources=[]; // Reset queueSources for new queue
 			for (let i = 0; i < action.songs.length; i++) {
-				newPlayState.queueSources = newPlayState.queueSources.concat([
+				newPlayState.queueSources.push(
 					{
 						sourceType: action.sourceType,
 						extractedUrlParams: action.extractedUrlParams,
 					},
-				]);
+				);
 			}
 			console.log("NEW QUEUE", newPlayState.queue);
 			return newPlayState;


### PR DESCRIPTION
Adds intuitive functionality for Player play button to play songs of CurrentView even if songs aren't manually added by the user.
* Utilizes `history` prop automatically passed by Auth routes in React Router to track `queueSource` type and `extractedUrlParams` for responsive UX
    * Play button in Show view will show Pause when current track was sourced from that view