### PR TITLE
Convert sourcetype to pathname

### DIFF
--- a/app/assets/stylesheets/12-artist-show.scss
+++ b/app/assets/stylesheets/12-artist-show.scss
@@ -115,11 +115,11 @@
     margin-bottom: 15px;
 }
 
-a.artist-link{
+a.artist-link {
     color: white;
 }
 
-a.artist-link a:hover {
+a.artist-link:hover {
     text-decoration: underline;
     cursor: pointer;
 }

--- a/app/assets/stylesheets/16-album-nav.scss
+++ b/app/assets/stylesheets/16-album-nav.scss
@@ -1,0 +1,20 @@
+.album-nav-dropdown {
+    align-items: flex-start;
+    font-size: 15px;
+    z-index: 2;
+    width: 150px;
+    height: auto;
+    padding: 3px;
+    background-color: #282828;
+    position: fixed;
+    color: white;
+    border-radius: 4px;
+    box-shadow: 0 16px 24px rgba(0, 0, 0, 0.3), 0 6px 8px rgba(0, 0, 0, 0.2);
+    left: 440px;
+    top: 365px;
+}
+
+.album-nav-submenu {
+    left: calc(440px + 160px);
+    top: 375px;
+}

--- a/app/assets/stylesheets/16-album-nav.scss
+++ b/app/assets/stylesheets/16-album-nav.scss
@@ -16,5 +16,8 @@
 
 .album-nav-submenu {
     left: calc(440px + 160px);
-    top: 375px;
+    top: 404px;
+    max-height: 250px;
+    overflow-y: scroll;
+    width: 250px;
 }

--- a/frontend/actions/now_playing_actions.js
+++ b/frontend/actions/now_playing_actions.js
@@ -7,6 +7,7 @@ export const PLAY_PLAYLIST = "PLAY_PLAYLIST";
 export const QUEUE_ALBUM = "QUEUE_ALBUM";
 export const PLAY_ALBUM = "PLAY_ALBUM";
 export const PLAY_VIEW = "PLAY_VIEW";
+export const QUEUE_VIEW = "QUEUE_VIEW";
 
 const togglePlay = () => ({
 	type: TOGGLE_PLAY,
@@ -36,6 +37,14 @@ const queueAlbum = (objToQueue) => ({
 	//{albumSongs:arr, sourceType:str, extractedUrlParams:numStr}
 	type: QUEUE_ALBUM,
 	songs: objToQueue.albumSongs,
+	sourceType: objToQueue.sourceType,
+	extractedUrlParams: objToQueue.extractedUrlParams,
+});
+
+const queueView = (objToQueue) => ({
+	//{viewSongs:arr, sourceType:str, extractedUrlParams:numStr}
+	type: QUEUE_VIEW,
+	songs: objToQueue.viewSongs,
 	sourceType: objToQueue.sourceType,
 	extractedUrlParams: objToQueue.extractedUrlParams,
 });
@@ -101,6 +110,10 @@ export const toPlayAlbum = (objToQueue) => (dispatch) => {
 
 export const toPlayView = (objToQueue) => (dispatch) => {
 	return dispatch(playView(objToQueue));
+};
+
+export const toQueueView = (objToQueue) => (dispatch) => {
+	return dispatch(queueView(objToQueue));
 };
 
 export const toPushPlay = () => (dispatch) => dispatch(pushPlay());

--- a/frontend/actions/now_playing_actions.js
+++ b/frontend/actions/now_playing_actions.js
@@ -4,6 +4,8 @@ export const QUEUE_ARTIST = "QUEUE_ARTIST";
 export const PLAY_ARTIST = "PLAY_ARTIST";
 export const QUEUE_PLAYLIST = "QUEUE_PLAYLIST";
 export const PLAY_PLAYLIST = "PLAY_PLAYLIST";
+export const QUEUE_ALBUM = "QUEUE_ALBUM";
+export const PLAY_ALBUM = "PLAY_ALBUM";
 export const PLAY_VIEW = "PLAY_VIEW";
 
 const togglePlay = () => ({
@@ -30,6 +32,14 @@ const queuePlaylist = (objToQueue) => ({
 	extractedUrlParams: objToQueue.extractedUrlParams,
 });
 
+const queueAlbum = (objToQueue) => ({
+	//{albumSongs:arr, sourceType:str, extractedUrlParams:numStr}
+	type: QUEUE_ALBUM,
+	songs: objToQueue.albumSongs,
+	sourceType: objToQueue.sourceType,
+	extractedUrlParams: objToQueue.extractedUrlParams,
+});
+
 const playArtist = (objToQueue) => ({
 	//{allSongs:arr, sourceType:str, extractedUrlParams:numStr}
 	type: PLAY_ARTIST,
@@ -42,6 +52,14 @@ const playPlaylist = (objToQueue) => ({
 	//{playlistSongs:arr, sourceType:str, extractedUrlParams:numStr}
 	type: PLAY_PLAYLIST,
 	songs: objToQueue.playlistSongs,
+	sourceType: objToQueue.sourceType,
+	extractedUrlParams: objToQueue.extractedUrlParams,
+});
+
+const playAlbum = (objToQueue) => ({
+	//{albumSongs:arr, sourceType:str, extractedUrlParams:numStr}
+	type: PLAY_ALBUM,
+	songs: objToQueue.albumSongs,
 	sourceType: objToQueue.sourceType,
 	extractedUrlParams: objToQueue.extractedUrlParams,
 });
@@ -71,6 +89,14 @@ export const toPlayPlaylist = (objToQueue) => (dispatch) => {
 
 export const toQueuePlaylist = (objToQueue) => (dispatch) => {
 	return dispatch(queuePlaylist(objToQueue));
+};
+
+export const toQueueAlbum = (objToQueue) => (dispatch) => {
+	return dispatch(queueAlbum(objToQueue));
+};
+
+export const toPlayAlbum = (objToQueue) => (dispatch) => {
+	return dispatch(playAlbum(objToQueue));
 };
 
 export const toPlayView = (objToQueue) => (dispatch) => {

--- a/frontend/actions/now_playing_actions.js
+++ b/frontend/actions/now_playing_actions.js
@@ -18,68 +18,60 @@ const pushPlay = () => ({
 });
 
 const queueArtist = (objToQueue) => ({
-	//{allSongs:arr, sourceType:str, extractedUrlParams:numStr}
+	//{allSongs:arr, sourcedFrom:str, extractedUrlParams:numStr}
 	type: QUEUE_ARTIST,
 	songs: objToQueue.allSongs,
-	sourceType: objToQueue.sourceType,
-	extractedUrlParams: objToQueue.extractedUrlParams,
+	sourcedFrom: objToQueue.sourcedFrom,
 });
 
 const queuePlaylist = (objToQueue) => ({
-	//{playlistSongs:arr, sourceType:str, extractedUrlParams:numStr}
+	//{playlistSongs:arr, sourcedFrom:str, extractedUrlParams:numStr}
 	type: QUEUE_PLAYLIST,
 	songs: objToQueue.playlistSongs,
-	sourceType: objToQueue.sourceType,
-	extractedUrlParams: objToQueue.extractedUrlParams,
+	sourcedFrom: objToQueue.sourcedFrom,
 });
 
 const queueAlbum = (objToQueue) => ({
-	//{albumSongs:arr, sourceType:str, extractedUrlParams:numStr}
+	//{albumSongs:arr, sourcedFrom:str, extractedUrlParams:numStr}
 	type: QUEUE_ALBUM,
 	songs: objToQueue.albumSongs,
-	sourceType: objToQueue.sourceType,
-	extractedUrlParams: objToQueue.extractedUrlParams,
+	sourcedFrom: objToQueue.sourcedFrom,
 });
 
 const queueView = (objToQueue) => ({
-	//{viewSongs:arr, sourceType:str, extractedUrlParams:numStr}
+	//{viewSongs:arr, sourcedFrom:str, extractedUrlParams:numStr}
 	type: QUEUE_VIEW,
 	songs: objToQueue.viewSongs,
-	sourceType: objToQueue.sourceType,
-	extractedUrlParams: objToQueue.extractedUrlParams,
+	sourcedFrom: objToQueue.sourcedFrom,
 });
 
 const playArtist = (objToQueue) => ({
-	//{allSongs:arr, sourceType:str, extractedUrlParams:numStr}
+	//{allSongs:arr, sourcedFrom:str, extractedUrlParams:numStr}
 	type: PLAY_ARTIST,
 	songs: objToQueue.allSongs,
-	sourceType: objToQueue.sourceType,
-	extractedUrlParams: objToQueue.extractedUrlParams,
+	sourcedFrom: objToQueue.sourcedFrom,
 });
 
 const playPlaylist = (objToQueue) => ({
-	//{playlistSongs:arr, sourceType:str, extractedUrlParams:numStr}
+	//{playlistSongs:arr, sourcedFrom:str, extractedUrlParams:numStr}
 	type: PLAY_PLAYLIST,
 	songs: objToQueue.playlistSongs,
-	sourceType: objToQueue.sourceType,
-	extractedUrlParams: objToQueue.extractedUrlParams,
+	sourcedFrom: objToQueue.sourcedFrom,
 });
 
 const playAlbum = (objToQueue) => ({
-	//{albumSongs:arr, sourceType:str, extractedUrlParams:numStr}
+	//{albumSongs:arr, sourcedFrom:str, extractedUrlParams:numStr}
 	type: PLAY_ALBUM,
 	songs: objToQueue.albumSongs,
-	sourceType: objToQueue.sourceType,
-	extractedUrlParams: objToQueue.extractedUrlParams,
+	sourcedFrom: objToQueue.sourcedFrom,
 });
 
 const playView = (objToQueue) => {
 	return {
-	//{viewSongs:arr, sourceType:str, extractedUrlParams:numStr}
+	//{viewSongs:arr, sourcedFrom:str, extractedUrlParams:numStr}
 	type: PLAY_VIEW,
 	songs: objToQueue.viewSongs,
-	sourceType: objToQueue.sourceType,
-	extractedUrlParams: objToQueue.extractedUrlParams,
+	sourcedFrom: objToQueue.sourcedFrom,
 }};
 
 export const toTogglePlay = () => (dispatch) => dispatch(togglePlay());

--- a/frontend/components/albums/album_link.jsx
+++ b/frontend/components/albums/album_link.jsx
@@ -1,24 +1,27 @@
 import React from "react";
 
-const ArtistLink = ({
-    artist,
-    currentArtist,
+const AlbumLink = ({
+    album,
+    currentAlbum,
     history,
 }) => {
 
+console.log("album", album)
+console.log("currentAlbum", currentAlbum)
+
     const { id,
         name,
-    } = artist;
+    } = album;
 
     const handleClick = (e) => {
         e.preventDefault();
-        return history.push(`/artist/${id}`);
+        return history.push(`/album/${id}`);
     }
 
-    if (currentArtist === null) {
+    if (currentAlbum === null) {
         return <a onClick={handleClick} className="artist-link">{name}</a>
     } else {
-        if (name === currentArtist.name) {
+        if (name === currentAlbum.name) {
             return <span>{name}</span>
         } else {
             return <a onClick={handleClick} className="artist-link">{name}</a>
@@ -26,4 +29,4 @@ const ArtistLink = ({
     }
 }
 
-export default ArtistLink;
+export default AlbumLink;

--- a/frontend/components/albums/album_link.jsx
+++ b/frontend/components/albums/album_link.jsx
@@ -6,9 +6,6 @@ const AlbumLink = ({
     history,
 }) => {
 
-console.log("album", album)
-console.log("currentAlbum", currentAlbum)
-
     const { id,
         name,
     } = album;

--- a/frontend/components/albums/album_link_container.js
+++ b/frontend/components/albums/album_link_container.js
@@ -1,0 +1,10 @@
+import { connect } from "react-redux";
+import { displayAlbum,
+} from "../../actions/artist_actions";
+import AlbumLink from "./album_link";
+
+const mapDispatchtoProps = (dispatch) => ({
+	displayAlbum: (albumId) => dispatch(displayAlbum(albumId)),
+});
+
+export default connect(null, mapDispatchtoProps)(AlbumLink);

--- a/frontend/components/albums/album_nav.jsx
+++ b/frontend/components/albums/album_nav.jsx
@@ -6,7 +6,7 @@ import AlbumNavDropdownContainer from "./album_nav_dropdown_container";
 import { RxDotsHorizontal } from "react-icons/rx";
 import { GrPlayFill } from "react-icons/gr";
 
-const AlbumNav = ({ playlists }) => {
+const AlbumNav = ({ tracks, playlists, history }) => {
 	// const toggleAlbumNavDropdown = (event) => {
 	//     event.preventDefault();
 	//     playlistNavDropdownState.isOpen ? closePlaylistNavDropdown() : openPlaylistNavDropdown();
@@ -18,15 +18,13 @@ const AlbumNav = ({ playlists }) => {
 	});
 
 	// Updater functions for local states
-    const updateAlbumNavDropdownState = (newState) => {
-        setAlbumNavDropdownState(newState);
-    }
+	const updateAlbumNavDropdownState = (newState) => {
+		setAlbumNavDropdownState(newState);
+	};
 
 	const toggleAlbumNavDropdown = (e) => {
 		e.preventDefault();
-		if (!albumNavDropdownState.isOpen) {
-			updateAlbumNavDropdownState({ isOpen: true });
-		}
+		setAlbumNavDropdownState({isOpen: !albumNavDropdownState.isOpen});
 	};
 
 	const albumNavDropdownItems = [
@@ -48,6 +46,17 @@ const AlbumNav = ({ playlists }) => {
 		},
 	];
 
+	const pathname = history.location.pathname;
+	const sourceType = pathname.split("/")[1];
+	const extractedUrlParams = pathname.split("/")[2];
+	const objToQueue = {
+		viewSongs: tracks,
+		sourceType,
+		extractedUrlParams,
+	}; // provides linkback to view currently playing
+
+	const albumNavRef = useRef();
+
 	return (
 		<>
 			<div id="playlist-play-button">
@@ -57,8 +66,10 @@ const AlbumNav = ({ playlists }) => {
 				<RxDotsHorizontal />
 			</div>
 			<AlbumNavDropdownContainer
+				ref={albumNavRef}
 				albumNavDropdownState={albumNavDropdownState}
-                items={albumNavDropdownItems}
+				items={albumNavDropdownItems}
+				updateAlbumNavDropdownState={updateAlbumNavDropdownState}
 			/>
 		</>
 	);

--- a/frontend/components/albums/album_nav.jsx
+++ b/frontend/components/albums/album_nav.jsx
@@ -44,13 +44,9 @@ const AlbumNav = ({ tracks, playlists, history }) => {
 		},
 	];
 
-	const pathname = history.location.pathname;
-	const sourceType = pathname.split("/")[1];
-	const extractedUrlParams = pathname.split("/")[2];
 	const objToQueue = {
 		viewSongs: tracks,
-		sourceType,
-		extractedUrlParams,
+		sourcedFrom: history.location.pathname,
 	}; // provides linkback to view currently playing
 
 	const albumNavRef = useRef();

--- a/frontend/components/albums/album_nav.jsx
+++ b/frontend/components/albums/album_nav.jsx
@@ -1,24 +1,67 @@
 import React from "react";
+import { useState, useEffect, useRef } from "react";
+
+import AlbumNavDropdownContainer from "./album_nav_dropdown_container";
 
 import { RxDotsHorizontal } from "react-icons/rx";
 import { GrPlayFill } from "react-icons/gr";
 
-const AlbumNav = ({ props }) => {
-    // const toggleAlbumNavDropdown = (event) => {
-    //     event.preventDefault();
-    //     playlistNavDropdownState.isOpen ? closePlaylistNavDropdown() : openPlaylistNavDropdown();
-    // }
+const AlbumNav = ({ playlists }) => {
+	// const toggleAlbumNavDropdown = (event) => {
+	//     event.preventDefault();
+	//     playlistNavDropdownState.isOpen ? closePlaylistNavDropdown() : openPlaylistNavDropdown();
+	// }
 
-    return (
-        <>
-            <div id="playlist-play-button">
-                <GrPlayFill />
-            </div>
-            <div id="playlist-dropdown-dots">
-                <RxDotsHorizontal />
-            </div>
-        </>
-    );
+	// Set local states for AlbumNavDropdownState
+	const [albumNavDropdownState, setAlbumNavDropdownState] = useState({
+		isOpen: false,
+	});
+
+	// Updater functions for local states
+    const updateAlbumNavDropdownState = (newState) => {
+        setAlbumNavDropdownState(newState);
+    }
+
+	const toggleAlbumNavDropdown = (e) => {
+		e.preventDefault();
+		if (!albumNavDropdownState.isOpen) {
+			updateAlbumNavDropdownState({ isOpen: true });
+		}
+	};
+
+	const albumNavDropdownItems = [
+		{
+			title: "Add to queue",
+		},
+		{
+			title: "Add to playlist",
+			submenu: [
+				[
+					{
+						title: "Create new playlist",
+					},
+					...playlists,
+					// Enclose array of playlists in an array since
+					// dropdown uses recursive .map function on items prop
+				],
+			],
+		},
+	];
+
+	return (
+		<>
+			<div id="playlist-play-button">
+				<GrPlayFill />
+			</div>
+			<div id="playlist-dropdown-dots" onClick={toggleAlbumNavDropdown}>
+				<RxDotsHorizontal />
+			</div>
+			<AlbumNavDropdownContainer
+				albumNavDropdownState={albumNavDropdownState}
+                items={albumNavDropdownItems}
+			/>
+		</>
+	);
 };
 
 export default AlbumNav;

--- a/frontend/components/albums/album_nav.jsx
+++ b/frontend/components/albums/album_nav.jsx
@@ -34,14 +34,12 @@ const AlbumNav = ({ tracks, playlists, history }) => {
 		{
 			title: "Add to playlist",
 			submenu: [
-				[
 					{
 						title: "Create new playlist",
 					},
 					...playlists,
 					// Enclose array of playlists in an array since
 					// dropdown uses recursive .map function on items prop
-				],
 			],
 		},
 	];

--- a/frontend/components/albums/album_nav_dropdown.jsx
+++ b/frontend/components/albums/album_nav_dropdown.jsx
@@ -1,26 +1,32 @@
 import React, { useState, useEffect, forwardRef } from "react";
 
+import SongCardDropdownItem from "../songs/song_card_dropdown_item";
+import AlbumNavSubmenu from "./album_nav_submenu";
+
 
 const AlbumNavDropdown = forwardRef(
 	(
 		{
 			songs,
 			playlists,
+            selectedSong,
+            currentItem,
 			currentUser,
 			albumNavDropdownState,
 			updateAlbumNavDropdownState,
 			items,
 			depthLevel,
+            submenuState,
 			removePlaylisted,
 			createNewPlaylisted,
 			createPlaylist,
 			displayPlaylist,
-            toQueueAlbum,
+            toQueueView,
             toPlayAlbum,
 		},
 		ref
 	) => {
-		console.log(albumNavDropdownState);
+
         // Set local state for albumNavSubmenu
 		const [albumNavSubmenuState, setAlbumNavSubmenuState] = useState({
 			isOpen: false,
@@ -28,6 +34,7 @@ const AlbumNavDropdown = forwardRef(
 
 		// Add event listeners when menu is open; remove when menu is closed
 		useEffect(() => {
+            console.log("albumNavDropdownState", albumNavDropdownState);
 			const whenMenuIsOpen = (event) => {
 				if (
 					albumNavDropdownState.isOpen &&
@@ -35,7 +42,8 @@ const AlbumNavDropdown = forwardRef(
 					!ref?.current?.contains(event.target)
 				) {
 					updateAlbumNavDropdownState({ isOpen: false });
-					setSubmenuState({ isOpen: false });
+                    console.log(albumNavDropdownState)
+
 				}
 			};
 			document.addEventListener("mousedown", whenMenuIsOpen);
@@ -47,8 +55,84 @@ const AlbumNavDropdown = forwardRef(
 			};
 		}, [albumNavDropdownState]);
 
+        const toggleSubmenuAndPlaceDropdown = (e) => {
+            e.preventDefault();
+            setAlbumNavSubmenuState({ isOpen: !albumNavSubmenuState.isOpen });
+            console.log("albumNavSubmenuState", albumNavSubmenuState)
+        };
 
-		return <div className="playlist-dropdown">THIS IS NAV DROPDOWN</div>;
+		return (
+			<div
+				className={`album-nav-dropdown dropdown-submenu ${
+					albumNavDropdownState.isOpen ? "show" : ""
+				}`}
+				data-dropdown
+				ref={ref}
+				// style={{
+				// 	left: `${dropdownPosition.left}px`,
+				// 	top: `${dropdownPosition.top}px`,
+				// 	...depthStyling,
+				// }}
+			>
+				{items.map((item, index) =>
+					item.submenu ? (
+						// If a submenu exists, create button for submenu title and pass submenu to AlbumNavSubmenu
+						<React.Fragment
+							key={`${selectedSong.playlistedId}+${depthLevel}+${item.title}+"w-submenu"`}
+						>
+							<button
+								className="song-card-dropdown-item"
+								onClick={toggleSubmenuAndPlaceDropdown}
+							>
+								{item.title}{" "}
+								<span key={`${selectedSong.playlistedId}`}>
+									&raquo;
+								</span>
+							</button>
+							<AlbumNavSubmenu
+								songs={songs}
+								playlists={playlists}
+								selectedSong={selectedSong}
+								currentItem={currentItem}
+								currentUser={currentUser}
+								submenu={item.submenu}
+								submenuState={albumNavSubmenuState}
+								depthLevel={depthLevel}
+								// dropdownPosition={dropdownPosition}
+								updateSongCardDropdownState={
+									updateAlbumNavDropdownState
+								}
+								removePlaylisted={removePlaylisted}
+								createNewPlaylisted={createNewPlaylisted}
+								createPlaylist={createPlaylist}
+								displayPlaylist={displayPlaylist}
+								toQueueView={toQueueView}
+							/>
+						</React.Fragment>
+					) : (
+						<SongCardDropdownItem // Else, create just a button
+							key={`${selectedSong.playlistedId}+${item.id}+${depthLevel}+"no-subm"`}
+							currentItem={currentItem}
+							playlists={playlists}
+							currentUser={currentUser}
+							selectedIndex={index - 1} // Since the first item is "Create new playlist"
+							selectedSong={selectedSong}
+							updateSongCardDropdownState={
+								updateAlbumNavDropdownState
+							}
+							item={item}
+							depthLevel={depthLevel}
+							// dropdownPosition={dropdownPosition}
+							removePlaylisted={removePlaylisted}
+							createNewPlaylisted={createNewPlaylisted}
+							createPlaylist={createPlaylist}
+							displayPlaylist={displayPlaylist}
+							toQueueView={toQueueView}
+						/>
+					)
+				)}
+			</div>
+		);
 	}
 );
 

--- a/frontend/components/albums/album_nav_dropdown.jsx
+++ b/frontend/components/albums/album_nav_dropdown.jsx
@@ -1,17 +1,55 @@
-import React, { useEffect } from "react";
+import React, { useState, useEffect, forwardRef } from "react";
 
 
-const AlbumNavDropdown = ({ props }) => {
+const AlbumNavDropdown = forwardRef(
+	(
+		{
+			songs,
+			playlists,
+			currentUser,
+			albumNavDropdownState,
+			updateAlbumNavDropdownState,
+			items,
+			depthLevel,
+			removePlaylisted,
+			createNewPlaylisted,
+			createPlaylist,
+			displayPlaylist,
+            toQueueAlbum,
+            toPlayAlbum,
+		},
+		ref
+	) => {
+		console.log(albumNavDropdownState);
+        // Set local state for albumNavSubmenu
+		const [albumNavSubmenuState, setAlbumNavSubmenuState] = useState({
+			isOpen: false,
+		});
 
-    useEffect( () => {
+		// Add event listeners when menu is open; remove when menu is closed
+		useEffect(() => {
+			const whenMenuIsOpen = (event) => {
+				if (
+					albumNavDropdownState.isOpen &&
+					ref?.current &&
+					!ref?.current?.contains(event.target)
+				) {
+					updateAlbumNavDropdownState({ isOpen: false });
+					setSubmenuState({ isOpen: false });
+				}
+			};
+			document.addEventListener("mousedown", whenMenuIsOpen);
+			document.addEventListener("touchstart", whenMenuIsOpen);
+			return () => {
+				// Cleanup the event listener when component unmounts
+				document.removeEventListener("mousedown", whenMenuIsOpen);
+				document.removeEventListener("touchstart", whenMenuIsOpen);
+			};
+		}, [albumNavDropdownState]);
 
-        return () => {
-            
-        }
-    }, [])
 
-    return <div className="playlist-dropdown">
-        THIS IS NAV DROPDOWN
-    </div>
+		return <div className="playlist-dropdown">THIS IS NAV DROPDOWN</div>;
+	}
+);
 
-}
+export default AlbumNavDropdown;

--- a/frontend/components/albums/album_nav_dropdown.jsx
+++ b/frontend/components/albums/album_nav_dropdown.jsx
@@ -31,6 +31,9 @@ const AlbumNavDropdown = forwardRef(
 		const [albumNavSubmenuState, setAlbumNavSubmenuState] = useState({
 			isOpen: false,
 		});
+        const updateAlbumNavSubmenuState = (newState) => {
+            setAlbumNavSubmenuState(newState);
+        };
 
 		// Add event listeners when menu is open; remove when menu is closed
 		useEffect(() => {
@@ -99,9 +102,10 @@ const AlbumNavDropdown = forwardRef(
 								submenuState={albumNavSubmenuState}
 								depthLevel={depthLevel}
 								// dropdownPosition={dropdownPosition}
-								updateSongCardDropdownState={
+								updateAlbumNavDropdownState={
 									updateAlbumNavDropdownState
 								}
+                                updateAlbumNavSubmenuState={updateAlbumNavSubmenuState}
 								removePlaylisted={removePlaylisted}
 								createNewPlaylisted={createNewPlaylisted}
 								createPlaylist={createPlaylist}

--- a/frontend/components/albums/album_nav_dropdown_container.js
+++ b/frontend/components/albums/album_nav_dropdown_container.js
@@ -1,0 +1,46 @@
+import { connect } from "react-redux";
+
+import {
+	removePlaylisted,
+	createNewPlaylisted,
+} from "../../actions/playlisted_actions";
+import {
+	createPlaylist,
+	displayPlaylist,
+} from "../../actions/playlist_actions";
+import { toQueueAlbum,
+    toPlayAlbum,
+} from "../../actions/now_playing_actions";
+import AlbumNavDropdown from "./album_nav_dropdown";
+
+
+const mapStateToProps = (state, ownProps) => {
+	// Relocate each instance of recursive SongCardDrodpown
+	if (ownProps.depthLevel === 1) nextLeft -= 100; //submenu div is wider
+	return {
+		ref: ownProps.ref,
+        songs: state.entities.songs,
+		playlists: state.entities.playlists,
+		currentUser: ownProps.currentUser,
+		albumNavDropdownState: ownProps.albumNavDropdownState,
+		updateAlbumNavDropdownState: ownProps.updateAlbumNavDropdownState,
+		items: ownProps.items, // already contains current playlists from SongIndex
+		depthLevel: ownProps.depthLevel,
+		submenuState: ownProps.submenuState,
+	};
+};
+
+const mapDispatchToProps = (dispatch) => ({
+	removePlaylisted: (playlistedId) =>
+		dispatch(removePlaylisted(playlistedId)),
+	createNewPlaylisted: (songId, playlistId) =>
+		dispatch(createNewPlaylisted(songId, playlistId)),
+	createPlaylist: (playlist) => dispatch(createPlaylist(playlist)),
+	displayPlaylist: (playlistId) => dispatch(displayPlaylist(playlistId)),
+    toQueueAlbum: (objToQueue) => dispatch(toQueueAlbum(objToQueue)),
+    toPlayAlbum: (objToQueue) => dispatch(toPlayAlbum(objToQueue)),
+});
+
+export default connect(mapStateToProps, mapDispatchToProps, null, {
+	forwardRef: true,
+})(AlbumNavDropdown);

--- a/frontend/components/albums/album_nav_dropdown_container.js
+++ b/frontend/components/albums/album_nav_dropdown_container.js
@@ -26,7 +26,7 @@ const mapStateToProps = (state, ownProps) => {
 		currentUser: ownProps.currentUser,
 		albumNavDropdownState: ownProps.albumNavDropdownState,
 		updateAlbumNavDropdownState: ownProps.updateAlbumNavDropdownState,
-		items: ownProps.items, // already contains current playlists from SongIndex
+		items: ownProps.items,
 		depthLevel: ownProps.depthLevel,
 		submenuState: ownProps.submenuState,
 	};

--- a/frontend/components/albums/album_nav_dropdown_container.js
+++ b/frontend/components/albums/album_nav_dropdown_container.js
@@ -8,7 +8,7 @@ import {
 	createPlaylist,
 	displayPlaylist,
 } from "../../actions/playlist_actions";
-import { toQueueAlbum,
+import { toQueueView,
     toPlayAlbum,
 } from "../../actions/now_playing_actions";
 import AlbumNavDropdown from "./album_nav_dropdown";
@@ -21,6 +21,8 @@ const mapStateToProps = (state, ownProps) => {
 		ref: ownProps.ref,
         songs: state.entities.songs,
 		playlists: state.entities.playlists,
+        selectedSong: state.entities.songs,
+        currentItem: state.entities.currentItem,
 		currentUser: ownProps.currentUser,
 		albumNavDropdownState: ownProps.albumNavDropdownState,
 		updateAlbumNavDropdownState: ownProps.updateAlbumNavDropdownState,
@@ -37,7 +39,7 @@ const mapDispatchToProps = (dispatch) => ({
 		dispatch(createNewPlaylisted(songId, playlistId)),
 	createPlaylist: (playlist) => dispatch(createPlaylist(playlist)),
 	displayPlaylist: (playlistId) => dispatch(displayPlaylist(playlistId)),
-    toQueueAlbum: (objToQueue) => dispatch(toQueueAlbum(objToQueue)),
+    toQueueView: (objToQueue) => dispatch(toQueueView(objToQueue)),
     toPlayAlbum: (objToQueue) => dispatch(toPlayAlbum(objToQueue)),
 });
 

--- a/frontend/components/albums/album_nav_submenu.jsx
+++ b/frontend/components/albums/album_nav_submenu.jsx
@@ -1,0 +1,83 @@
+import React from "react";
+import { useEffect, useRef } from "react";
+import SongCardDropdownItem from "../songs/song_card_dropdown_item";
+
+const AlbumNavSubmenu = ({
+	songs,
+	playlists,
+	selectedSong,
+	currentItem,
+	currentUser,
+	submenu,
+	submenuState,
+	depthLevel,
+	updateAlbumNavDropdownState,
+	removePlaylisted,
+	createNewPlaylisted,
+	createPlaylist,
+	displayPlaylist,
+	toQueueView,
+}) => {
+	depthLevel += 1;
+	const dropdownClass = depthLevel > 0 ? "dropdown-submenu" : "";
+
+	const ref = useRef();
+
+	useEffect(() => {
+		console.log("submenuState", submenuState);
+		const whenMenuIsOpen = (event) => {
+			if (
+				submenuState.isOpen &&
+				ref?.current &&
+				!ref?.current?.contains(event.target)
+			) {
+				updateAlbumNavDropdownState({ isOpen: false });
+				console.log(submenuState);
+			}
+		};
+		document.addEventListener("mousedown", whenMenuIsOpen);
+		document.addEventListener("touchstart", whenMenuIsOpen);
+		return () => {
+			// Cleanup the event listener when component unmounts
+			document.removeEventListener("mousedown", whenMenuIsOpen);
+			document.removeEventListener("touchstart", whenMenuIsOpen);
+		};
+	}, [submenuState]);
+
+	return (
+		<div
+			className={`album-nav-dropdown album-nav-submenu dropdown-submenu ${dropdownClass} ${
+				submenuState.isOpen ? "show" : ""
+			}`}
+			ref={ref}
+			data-dropdown
+		>
+			{submenu.map((item, index) => {
+				debugger
+				return (
+					<SongCardDropdownItem // Else, create just a button
+						key={`${selectedSong.playlistedId}+${item.id}+${depthLevel}+"no-subm"`}
+						currentItem={currentItem}
+						playlists={playlists}
+						currentUser={currentUser}
+						selectedIndex={index - 1} // Since the first item is "Create new playlist"
+						selectedSong={selectedSong}
+						updateSongCardDropdownState={
+							updateAlbumNavDropdownState
+						}
+						item={item}
+						depthLevel={depthLevel}
+						// dropdownPosition={dropdownPosition}
+						removePlaylisted={removePlaylisted}
+						createNewPlaylisted={createNewPlaylisted}
+						createPlaylist={createPlaylist}
+						displayPlaylist={displayPlaylist}
+						toQueueView={toQueueView}
+					/>
+				);
+			})}
+		</div>
+	);
+};
+
+export default AlbumNavSubmenu;

--- a/frontend/components/albums/album_nav_submenu.jsx
+++ b/frontend/components/albums/album_nav_submenu.jsx
@@ -12,6 +12,7 @@ const AlbumNavSubmenu = ({
 	submenuState,
 	depthLevel,
 	updateAlbumNavDropdownState,
+	updateAlbumNavSubmenuState,
 	removePlaylisted,
 	createNewPlaylisted,
 	createPlaylist,
@@ -32,7 +33,7 @@ const AlbumNavSubmenu = ({
 				!ref?.current?.contains(event.target)
 			) {
 				updateAlbumNavDropdownState({ isOpen: false });
-				console.log(submenuState);
+				updateAlbumNavSubmenuState({ isOpen: false });
 			}
 		};
 		document.addEventListener("mousedown", whenMenuIsOpen);
@@ -46,14 +47,13 @@ const AlbumNavSubmenu = ({
 
 	return (
 		<div
-			className={`album-nav-dropdown album-nav-submenu dropdown-submenu ${dropdownClass} ${
+			className={`song-card-dropdown album-nav-dropdown album-nav-submenu dropdown-submenu ${dropdownClass} ${
 				submenuState.isOpen ? "show" : ""
 			}`}
 			ref={ref}
 			data-dropdown
 		>
 			{submenu.map((item, index) => {
-				debugger
 				return (
 					<SongCardDropdownItem // Else, create just a button
 						key={`${selectedSong.playlistedId}+${item.id}+${depthLevel}+"no-subm"`}

--- a/frontend/components/albums/album_show.jsx
+++ b/frontend/components/albums/album_show.jsx
@@ -5,46 +5,47 @@ import AlbumNav from "./album_nav";
 import SongIndex from "../songs/song_index";
 
 const AlbumShow = ({
-    currentAlbum,
-    tracks,
-    urlParams,
-    history,
-    currentUser,
-    source,
-    songCardDropdownItems,
-    displayAlbum,
-    clearCurrent,
+	currentAlbum,
+	tracks,
+	playlists,
+	urlParams,
+	history,
+	currentUser,
+	source,
+	songCardDropdownItems,
+	displayAlbum,
+	clearCurrent,
 }) => {
-    useEffect(() => {
-        displayAlbum(urlParams.id);
+	useEffect(() => {
+		displayAlbum(urlParams.id);
 
-        const rendered = document.getElementById("album-show");
-        rendered ? rendered.scrollTo(0, 0) : null;
+		const rendered = document.getElementById("album-show");
+		rendered ? rendered.scrollTo(0, 0) : null;
 
-        return () => clearCurrent();
-    }, [urlParams]); // Will run whenever urlParams.id changes, otherwise ArtistShow doesn't re-render
+		return () => clearCurrent();
+	}, [urlParams]); // Will run whenever urlParams.id changes, otherwise ArtistShow doesn't re-render
 
-    const albumShowRef = useRef();
+	const albumShowRef = useRef();
 
-    const albumShow = (
-        <div className="album-show" ref={albumShowRef}>
-            <div className="album-header">
-                <AlbumHeader album={currentAlbum} history={history} />
-            </div>
-            <div className="album-nav">
-                <AlbumNav />
-            </div>
-            <SongIndex
-                currentUser={currentUser}
-                songs={tracks}
-                history={history}
-                source={source}
-                songCardDropdownItems={songCardDropdownItems}
-                currentViewRef={albumShowRef}
-            />
-        </div>
-    );
-    return currentAlbum.albumPhotoUrl ? albumShow : null;
+	const albumShow = (
+		<div className="album-show" ref={albumShowRef}>
+			<div className="album-header">
+				<AlbumHeader album={currentAlbum} history={history} />
+			</div>
+			<div className="album-nav">
+				<AlbumNav playlists={playlists} />
+			</div>
+			<SongIndex
+				currentUser={currentUser}
+				songs={tracks}
+				history={history}
+				source={source}
+				songCardDropdownItems={songCardDropdownItems}
+				currentViewRef={albumShowRef}
+			/>
+		</div>
+	);
+	return currentAlbum.albumPhotoUrl ? albumShow : null;
 };
 
 export default AlbumShow;

--- a/frontend/components/albums/album_show.jsx
+++ b/frontend/components/albums/album_show.jsx
@@ -33,7 +33,7 @@ const AlbumShow = ({
 				<AlbumHeader album={currentAlbum} history={history} />
 			</div>
 			<div className="album-nav">
-				<AlbumNav playlists={playlists} />
+				<AlbumNav tracks={tracks} playlists={playlists} history={history} />
 			</div>
 			<SongIndex
 				currentUser={currentUser}

--- a/frontend/components/albums/album_show_container.js
+++ b/frontend/components/albums/album_show_container.js
@@ -17,6 +17,7 @@ const mapStateToProps = (
 	return {
 		currentAlbum: currentItem,
 		tracks: songs,
+		playlists: playlists,
 		urlParams: params,
 		history: history,
 		currentUser: currentUser,

--- a/frontend/components/artists/artist_page_menu_bar.jsx
+++ b/frontend/components/artists/artist_page_menu_bar.jsx
@@ -45,9 +45,7 @@ const ArtistPageMenuBar = ({
 		e.preventDefault();
 		if (
 			!!currentQueueSource &&
-			objToQueue.sourceType === currentQueueSource.sourceType &&
-			objToQueue.extractedUrlParams ===
-				currentQueueSource.extractedUrlParams
+			objToQueue.sourcedFrom === currentQueueSource.sourcedFrom
 		) {
 			toTogglePlay();
 		} else {
@@ -68,7 +66,7 @@ const ArtistPageMenuBar = ({
 		<>
 			<div id="artist-play-button" onClick={handleButtonClick}>
 				{isPlaying &&
-				objToQueue.sourceType === currentQueueSource.sourceType &&
+				objToQueue.sourcedFrom === currentQueueSource.sourcedFrom &&
 				objToQueue.extractedUrlParams ===
 					currentQueueSource.extractedUrlParams ? (
 					<MdOutlinePauseCircleFilled />

--- a/frontend/components/artists/artist_page_menu_bar.jsx
+++ b/frontend/components/artists/artist_page_menu_bar.jsx
@@ -18,7 +18,6 @@ const ArtistPageMenuBar = ({
 	toPlayArtist,
 	toPushPlay,
 	history,
-	urlParams,
 }) => {
 	const [artistPageDropdownState, setArtistPageDropdownState] = useState({
 		isOpen: false,
@@ -38,8 +37,7 @@ const ArtistPageMenuBar = ({
 
 	const objToQueue = {
 		allSongs,
-		sourceType: "artist",
-		extractedUrlParams: urlParams.id,
+		sourcedFrom: history.location.pathname,
 	}; // provides linkback to view currently playing
 	// TODO: Implement queue view
 
@@ -48,7 +46,8 @@ const ArtistPageMenuBar = ({
 		if (
 			!!currentQueueSource &&
 			objToQueue.sourceType === currentQueueSource.sourceType &&
-			objToQueue.extractedUrlParams === currentQueueSource.extractedUrlParams
+			objToQueue.extractedUrlParams ===
+				currentQueueSource.extractedUrlParams
 		) {
 			toTogglePlay();
 		} else {

--- a/frontend/components/artists/artist_show.jsx
+++ b/frontend/components/artists/artist_show.jsx
@@ -13,7 +13,6 @@ const ArtistShow = ({
 	isPlaying,
 	currentQueueSource,
 	urlParams,
-	path,
 	currentUser,
 	history,
 	displayArtist,
@@ -59,7 +58,6 @@ const ArtistShow = ({
 							toPlayArtist={toPlayArtist}
 							toPushPlay={toPushPlay}
 							history={history}
-							urlParams={urlParams}
 						/>
 					</div>
 					{albums?.length > 0 && (

--- a/frontend/components/artists/artist_show_container.js
+++ b/frontend/components/artists/artist_show_container.js
@@ -19,9 +19,8 @@ const mapStateToProps = (state, ownProps) => {
 		allSongs: state.entities.songs.allSongs,
 		collabSongs: state.entities.songs.collabSongs,
 		isPlaying: state.entities.nowPlaying.isPlaying,
-		currentQueueSource: state.entities.nowPlaying.queueSources[0], // = {sourceType:, urlParams:}
+		currentQueueSource: state.entities.nowPlaying.queueSources[0],
 		urlParams: ownProps.params,
-		path: ownProps.path,
 		currentUser: ownProps.currentUser,
 		history: ownProps.history,
 	};

--- a/frontend/components/player/now_playing_info.jsx
+++ b/frontend/components/player/now_playing_info.jsx
@@ -1,9 +1,13 @@
 import React, { useEffect } from "react";
+import AlbumLinkContainer from "../albums/album_link_container";
+import ArtistLinkContainer from "../artists/artist_link_container";
 
 const NowPlayingInfo = ({
 	audioRef,
 	track,
 	trackProgress,
+	pathname,
+	history,
 	length, // Refreshes component whenever queue changes
 	isPlaying,
 	updateTrackProgress,
@@ -31,9 +35,22 @@ const NowPlayingInfo = ({
 						{albumImageUrl && <img src={albumImageUrl} />}
 					</div>
 					<div className="now-playing-info">
-						<div className="now-playing-title">{title}</div>
+						<div className="now-playing-title">
+							<AlbumLinkContainer
+								album={{
+									id: track.albumId,
+									name: title ,
+								}}
+								currentAlbum={null}
+								history={history}
+							/>
+						</div>
 						<div className="now-playing-artist">
-							{songArtist.name}
+							<ArtistLinkContainer
+								artist={songArtist}
+								currentArtist={null}
+								history={history}
+							/>
 						</div>
 					</div>
 					<div className="now-playing-buttons"></div>

--- a/frontend/components/player/now_playing_info.jsx
+++ b/frontend/components/player/now_playing_info.jsx
@@ -6,7 +6,6 @@ const NowPlayingInfo = ({
 	audioRef,
 	track,
 	trackProgress,
-	pathname,
 	history,
 	length, // Refreshes component whenever queue changes
 	isPlaying,

--- a/frontend/components/player/player.jsx
+++ b/frontend/components/player/player.jsx
@@ -3,9 +3,10 @@ import NowPlayingInfo from "./now_playing_info";
 import PlayingControls from "./playing_controls";
 
 const Player = ({
-	pathname,
 	tracks,
 	songs,
+	pathname,
+	history,
 	isPlaying,
 	hasQueue,
 	toPlayView,
@@ -109,6 +110,8 @@ const Player = ({
 				audioRef={audioRef}
 				track={currentTrack}
 				trackProgress={trackProgress}
+				pathname={pathname}
+				history={history}
 				isPlaying={isPlaying}
 				updateTrackProgress={updateTrackProgress}
 			/>

--- a/frontend/components/player/player.jsx
+++ b/frontend/components/player/player.jsx
@@ -5,7 +5,6 @@ import PlayingControls from "./playing_controls";
 const Player = ({
 	tracks,
 	songs,
-	pathname,
 	history,
 	isPlaying,
 	hasQueue,
@@ -96,12 +95,9 @@ const Player = ({
 		}
 	};
 
-	const sourceType = pathname.split("/")[1];
-	const extractedUrlParams = pathname.split("/")[2];
 	const objToQueue = {
 		viewSongs: songs,
-		sourceType,
-		extractedUrlParams,
+		sourcedFrom: history.location.pathname,
 	}; // provides linkback to view currently playing
 
 	return (
@@ -110,7 +106,6 @@ const Player = ({
 				audioRef={audioRef}
 				track={currentTrack}
 				trackProgress={trackProgress}
-				pathname={pathname}
 				history={history}
 				isPlaying={isPlaying}
 				updateTrackProgress={updateTrackProgress}

--- a/frontend/components/player/player_container.js
+++ b/frontend/components/player/player_container.js
@@ -18,6 +18,7 @@ const mapStateToProps = (state, ownProps) => {
 		// matchObj is a prop passed down by AuthRoute
 		// matchObj = {params, path, url} as keys
 		pathname: ownProps.history.location.pathname,
+		history: ownProps.history,
 	};
 };
 

--- a/frontend/components/player/player_container.js
+++ b/frontend/components/player/player_container.js
@@ -17,7 +17,6 @@ const mapStateToProps = (state, ownProps) => {
 		hasQueue: state.entities.nowPlaying.queue.length > 0,
 		// matchObj is a prop passed down by AuthRoute
 		// matchObj = {params, path, url} as keys
-		pathname: ownProps.history.location.pathname,
 		history: ownProps.history,
 	};
 };

--- a/frontend/components/player/playing_controls.jsx
+++ b/frontend/components/player/playing_controls.jsx
@@ -21,7 +21,7 @@ const PlayingControls = ({
 
 	const handleClick = (e) => {
 		e.preventDefault();
-		if (objToQueue.sourceType === "artist") {
+		if (objToQueue.sourcedFrom.split("/")[1] === "artist") {
 			// Accounts for unique currentItem slice of state when ArtistShow view
 			objToQueue.viewSongs = objToQueue.viewSongs.allSongs;
 		}

--- a/frontend/components/playlists/playlist_nav.jsx
+++ b/frontend/components/playlists/playlist_nav.jsx
@@ -50,15 +50,14 @@ const PlaylistNav = ({
 
 	const objToQueue = {
 		playlistSongs,
-		sourceType: "playlist",
-		extractedUrlParams: urlParams.id,
+		sourcedFrom: history.location.pathname,
 	}; // provides linkback to view currently playing
 	// TODO: Implement queue view
 
 	const handleButtonClick = (e) => {
 		e.preventDefault();
-        console.log("CURRENT", currentQueueSource)
-        console.log("OBJ", objToQueue)
+		console.log("CURRENT", currentQueueSource);
+		console.log("OBJ", objToQueue);
 		if (
 			!!currentQueueSource &&
 			objToQueue.sourceType === currentQueueSource.sourceType &&

--- a/frontend/components/playlists/playlist_nav.jsx
+++ b/frontend/components/playlists/playlist_nav.jsx
@@ -30,13 +30,6 @@ const PlaylistNav = ({
 	closePlaylistEditModal,
 }) => {
 	useEffect(() => {
-		// UseEffect takes 2 args, a callback function and an array of dependencies
-		// that will trigger a re-render.
-		// setTimeout takes 2 args, an anonymous function and # of milliseconds.
-		// It turns the updating callback function into an async function which will
-		// wait until all the synchronous code has run before executing.
-		// It will allow the Component to load before running updater function again.
-		// Otherwise the eventListener will come on and then come off immediately.
 		if (!playlistNavDropdownState.isOpen)
 			window.removeEventListener("click", closePlaylistNavDropdown);
 	}, [playlistNavDropdownState]);

--- a/frontend/components/playlists/playlist_nav.jsx
+++ b/frontend/components/playlists/playlist_nav.jsx
@@ -60,9 +60,7 @@ const PlaylistNav = ({
 		console.log("OBJ", objToQueue);
 		if (
 			!!currentQueueSource &&
-			objToQueue.sourceType === currentQueueSource.sourceType &&
-			objToQueue.extractedUrlParams ===
-				currentQueueSource.extractedUrlParams
+			objToQueue.sourcedFrom === currentQueueSource.sourcedFrom
 		) {
 			toTogglePlay();
 		} else {
@@ -75,9 +73,7 @@ const PlaylistNav = ({
 		<>
 			<div id="artist-play-button" onClick={handleButtonClick}>
 				{isPlaying &&
-				objToQueue.sourceType === currentQueueSource.sourceType &&
-				objToQueue.extractedUrlParams ===
-					currentQueueSource.extractedUrlParams ? (
+				objToQueue.sourcedFrom === currentQueueSource.sourcedFrom ? (
 					<MdOutlinePauseCircleFilled />
 				) : (
 					<MdOutlinePlayCircleFilled />

--- a/frontend/components/playlists/playlist_nav_dropdown.jsx
+++ b/frontend/components/playlists/playlist_nav_dropdown.jsx
@@ -16,6 +16,13 @@ const PlaylistNavDropdown = ({
     toQueuePlaylist,
 }) => {
 	useEffect(() => {
+		// UseEffect takes 2 args, a callback function and an array of dependencies
+		// that will trigger a re-render.
+		// setTimeout takes 2 args, an anonymous function and # of milliseconds.
+		// It turns the updating callback function into an async function which will
+		// wait until all the synchronous code has run before executing.
+		// It will allow the Component to load before running updater function again.
+		// Otherwise the eventListener will come on and then come off immediately.
 		setTimeout(() => {
 			if (
 				playlistNavDropdownState.isOpen &&

--- a/frontend/components/songs/song_card.jsx
+++ b/frontend/components/songs/song_card.jsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState, useRef } from "react";
 
 import { RxDotsHorizontal } from "react-icons/rx";
 import ArtistLinkContainer from "../artists/artist_link_container";
+import AlbumLinkContainer from "../albums/album_link_container";
 
 const SongCard = ({
     source,
@@ -92,7 +93,16 @@ const SongCard = ({
                 </div>
             </div>
             <div className="song-card-album">
-                {source === "playlist" ? `${album}` : null}
+                {source === "playlist" ? 
+                    <AlbumLinkContainer
+                        album={{
+                            id: albumId,
+                            name: album,
+                        }}
+                        currentAlbum={null}
+                        history={history}
+                    />
+                    : null}
             </div>
             <div className="song-card-liked">&hearts;</div>
             <div className="song-card-duration">

--- a/frontend/components/songs/song_card_dropdown.jsx
+++ b/frontend/components/songs/song_card_dropdown.jsx
@@ -9,7 +9,6 @@ const SongCardDropdown = forwardRef(
             currentItem,
             playlists,
             currentUser,
-            history,
             selectedSong,
             songCardDropdownState,
             updateSongCardDropdownState,
@@ -87,7 +86,6 @@ const SongCardDropdown = forwardRef(
                                 </span>
                             </button>
                             <SongCardSubmenu
-                                history={history}
                                 currentUser={currentUser}
                                 selectedSong={selectedSong}
                                 songCardDropdownState={songCardDropdownState}
@@ -105,7 +103,6 @@ const SongCardDropdown = forwardRef(
                             key={`${selectedSong.playlistedId}+${item.id}+${depthLevel}+"no-subm"`}
                             currentItem={currentItem}
                             playlists={playlists}
-                            history={history}
                             currentUser={currentUser}
                             selectedIndex={index - 1} // Since the first item is "Create new playlist"
                             selectedSong={selectedSong}

--- a/frontend/components/songs/song_card_dropdown_container.jsx
+++ b/frontend/components/songs/song_card_dropdown_container.jsx
@@ -1,7 +1,5 @@
 import { connect } from "react-redux";
 
-import { isInViewport } from "../../modules/dropdown_functions";
-
 import {
     removePlaylisted,
     createNewPlaylisted,
@@ -24,7 +22,6 @@ const mapStateToProps = (state, ownProps) => {
         currentItem: state.entities.currentItem,
         playlists: state.entities.playlists,
         currentUser: ownProps.currentUser,
-        history: ownProps.history,
         selectedSong: ownProps.selectedSong,
         songCardDropdownState: ownProps.songCardDropdownState,
         updateSongCardDropdownState: ownProps.updateSongCardDropdownState,

--- a/frontend/components/songs/song_card_dropdown_item.jsx
+++ b/frontend/components/songs/song_card_dropdown_item.jsx
@@ -13,9 +13,12 @@ const SongCardDropdownItem = ({
     createNewPlaylisted,
     createPlaylist,
     displayPlaylist,
+    toQueueView,
 }) => {
     const runSongAction = (e) => {
-        if (e.target.innerText === "Remove from this playlist") {
+        if (e.target.innerText === "Add to queue") {
+            return toQueueView();
+        } else if (e.target.innerText === "Remove from this playlist") {
             updateSongCardDropdownState({ isOpen: false });
             return removePlaylisted(selectedSong.playlistedId);
         } else if (e.target.innerText === "Create new playlist") {

--- a/frontend/components/songs/song_card_dropdown_item.jsx
+++ b/frontend/components/songs/song_card_dropdown_item.jsx
@@ -4,7 +4,6 @@ const SongCardDropdownItem = ({
     currentItem,
     playlists,
     currentUser,
-    history,
     selectedIndex,
     selectedSong,
     updateSongCardDropdownState,

--- a/frontend/components/songs/song_card_submenu.jsx
+++ b/frontend/components/songs/song_card_submenu.jsx
@@ -16,8 +16,8 @@ const SongCardSubmenu = ({
     const dropdownClass = depthLevel > 0 ? "dropdown-submenu" : "";
 
     return (
-        <ul
-            className={`song-card-dropdown ${dropdownClass} ${
+        <div
+            className={`${dropdownClass} ${
                 submenuState.isOpen ? "show" : ""
             }`}
             data-dropdown
@@ -39,7 +39,7 @@ const SongCardSubmenu = ({
                     />
                 );
             })}
-        </ul>
+        </div>
     );
 };
 

--- a/frontend/components/songs/song_card_submenu.jsx
+++ b/frontend/components/songs/song_card_submenu.jsx
@@ -2,7 +2,6 @@ import React from "react";
 import SongCardDropdownContainer from "./song_card_dropdown_container";
 
 const SongCardSubmenu = ({
-    history,
     currentUser,
     selectedSong,
     songCardDropdownState,
@@ -26,7 +25,6 @@ const SongCardSubmenu = ({
                 return (
                     <SongCardDropdownContainer
                         key={`${index}+${depthLevel}+"subm"`}
-                        history={history}
                         currentUser={currentUser}
                         selectedSong={selectedSong}
                         songCardDropdownState={songCardDropdownState}

--- a/frontend/reducers/now_playing_reducer.js
+++ b/frontend/reducers/now_playing_reducer.js
@@ -38,8 +38,7 @@ const nowPlayingReducer = (
 			// Track the origin view of each song in the queue
 			for (let i = 0; i < action.songs.length; i++) {
 				newPlayState.queueSources.push({
-					sourceType: action.sourceType,
-					extractedUrlParams: action.extractedUrlParams,
+					sourcedFrom: action.sourcedFrom,
 				});
 			}
 			// TODO: Consider separate key to hold current track
@@ -54,8 +53,7 @@ const nowPlayingReducer = (
 			for (let i = 0; i < action.songs.length; i++) {
 				newPlayState.queueSources.push(
 					{
-						sourceType: action.sourceType,
-						extractedUrlParams: action.extractedUrlParams,
+						sourcedFrom: action.sourcedFrom,
 					},
 				);
 			}


### PR DESCRIPTION
Simplifies original `queueSource` from a manual object `(sourceType:, extractedUrlParams:)` to a simple string `/artist/7` through utilization of the `history` object prop passed by Auth Route
* ie. history.location.pathname →  “/playlist/4”

Reworks response UX code in nav and menu bars of each view to accommodate this change.