### PR TITLE
Expand and troubleshoot ArtistPageDropdown and AlbumNavDropdown

### DIFF
--- a/frontend/components/albums/album_nav.jsx
+++ b/frontend/components/albums/album_nav.jsx
@@ -23,6 +23,7 @@ const AlbumNav = ({ tracks, playlists, history }) => {
 	};
 
 	const albumNavDropdownItems = [
+		{ title: "Play album", id: `${crypto.randomUUID()}` },
 		{
 			title: "Add to queue",
 		},

--- a/frontend/components/albums/album_nav_dropdown.jsx
+++ b/frontend/components/albums/album_nav_dropdown.jsx
@@ -9,7 +9,6 @@ const AlbumNavDropdown = forwardRef(
 			history,
 			songs,
 			playlists,
-			selectedSong,
 			currentItem,
 			currentUser,
 			albumNavDropdownState,
@@ -58,7 +57,7 @@ const AlbumNavDropdown = forwardRef(
 			e.preventDefault();
 			setAlbumNavSubmenuState({ isOpen: !albumNavSubmenuState.isOpen });
 		};
-        
+        debugger
 		return (
 			<div
 				className={`album-nav-dropdown dropdown-submenu ${
@@ -71,14 +70,15 @@ const AlbumNavDropdown = forwardRef(
 					item.submenu ? (
 						// If a submenu exists, create button for submenu title and pass submenu to AlbumNavSubmenu
 						<React.Fragment
-							key={`${selectedSong.playlistedId}+${depthLevel}+${item.title}+"w-submenu"`}
+							key={`
+                            "albumnav"+${depthLevel}+${item.id}+"w-submenu"`}
 						>
 							<button
 								className="song-card-dropdown-item"
 								onClick={toggleSubmenuAndPlaceDropdown}
 							>
 								{item.title}{" "}
-								<span key={`${selectedSong.playlistedId}`}>
+								<span key={`item.id+"w-submenu`}>
 									&raquo;
 								</span>
 							</button>
@@ -86,7 +86,6 @@ const AlbumNavDropdown = forwardRef(
 								history={history}
 								songs={songs}
 								playlists={playlists}
-								selectedSong={selectedSong}
 								currentItem={currentItem}
 								currentUser={currentUser}
 								submenu={item.submenu}
@@ -109,13 +108,13 @@ const AlbumNavDropdown = forwardRef(
 						</React.Fragment>
 					) : (
 						<SongCardDropdownItem // Else, create just a button
-							key={`${selectedSong.playlistedId}+${item.id}+${depthLevel}+"no-subm"`}
+							key={`"albumnav-subm-button" + ${item.id}}`}
 							history={history}
 							currentItem={currentItem}
 							currentUser={currentUser}
 							playlists={playlists}
 							selectedIndex={index - 1} // Since the first item is "Create new playlist"
-							selectedSong={selectedSong}
+							selectedSong={songs}
 							updateSongCardDropdownState={
 								updateAlbumNavDropdownState
 							}

--- a/frontend/components/albums/album_nav_dropdown.jsx
+++ b/frontend/components/albums/album_nav_dropdown.jsx
@@ -57,7 +57,6 @@ const AlbumNavDropdown = forwardRef(
 			e.preventDefault();
 			setAlbumNavSubmenuState({ isOpen: !albumNavSubmenuState.isOpen });
 		};
-        debugger
 		return (
 			<div
 				className={`album-nav-dropdown dropdown-submenu ${

--- a/frontend/components/albums/album_nav_dropdown.jsx
+++ b/frontend/components/albums/album_nav_dropdown.jsx
@@ -20,7 +20,7 @@ const AlbumNavDropdown = forwardRef(
 			createPlaylist,
 			displayPlaylist,
 			toQueueView,
-			toPlayAlbum,
+			toPlayView,
             fetchPlaylists,
 		},
 		ref
@@ -77,9 +77,7 @@ const AlbumNavDropdown = forwardRef(
 								onClick={toggleSubmenuAndPlaceDropdown}
 							>
 								{item.title}{" "}
-								<span key={`item.id+"w-submenu`}>
-									&raquo;
-								</span>
+								<span key={`item.id+"w-submenu`}>&raquo;</span>
 							</button>
 							<AlbumNavSubmenu
 								history={history}
@@ -89,7 +87,7 @@ const AlbumNavDropdown = forwardRef(
 								currentUser={currentUser}
 								submenu={item.submenu}
 								submenuState={albumNavSubmenuState}
-								depthLevel={depthLevel+=1}
+								depthLevel={(depthLevel += 1)}
 								// dropdownPosition={dropdownPosition}
 								updateAlbumNavDropdownState={
 									updateAlbumNavDropdownState
@@ -101,8 +99,9 @@ const AlbumNavDropdown = forwardRef(
 								createNewPlaylisted={createNewPlaylisted}
 								createPlaylist={createPlaylist}
 								displayPlaylist={displayPlaylist}
-                                fetchPlaylists={fetchPlaylists}
+								fetchPlaylists={fetchPlaylists}
 								toQueueView={toQueueView}
+								toPlayView={toPlayView}
 							/>
 						</React.Fragment>
 					) : (
@@ -124,8 +123,9 @@ const AlbumNavDropdown = forwardRef(
 							createNewPlaylisted={createNewPlaylisted}
 							createPlaylist={createPlaylist}
 							displayPlaylist={displayPlaylist}
-                            fetchPlaylists={fetchPlaylists}
+							fetchPlaylists={fetchPlaylists}
 							toQueueView={toQueueView}
+							toPlayView={toPlayView}
 						/>
 					)
 				)}

--- a/frontend/components/albums/album_nav_dropdown.jsx
+++ b/frontend/components/albums/album_nav_dropdown.jsx
@@ -66,11 +66,6 @@ const AlbumNavDropdown = forwardRef(
 				}`}
 				data-dropdown
 				ref={ref}
-				// style={{
-				// 	left: `${dropdownPosition.left}px`,
-				// 	top: `${dropdownPosition.top}px`,
-				// 	...depthStyling,
-				// }}
 			>
 				{items.map((item, index) =>
 					item.submenu ? (

--- a/frontend/components/albums/album_nav_dropdown_container.js
+++ b/frontend/components/albums/album_nav_dropdown_container.js
@@ -9,7 +9,7 @@ import {
 	displayPlaylist,
 	fetchPlaylists,
 } from "../../actions/playlist_actions";
-import { toQueueView, toPlayAlbum } from "../../actions/now_playing_actions";
+import { toQueueView, toPlayView } from "../../actions/now_playing_actions";
 import AlbumNavDropdown from "./album_nav_dropdown";
 
 const mapStateToProps = (state, ownProps) => {
@@ -18,7 +18,6 @@ const mapStateToProps = (state, ownProps) => {
 		history: ownProps.history,
 		songs: state.entities.songs,
 		playlists: state.entities.playlists,
-		selectedSong: state.entities.songs,
 		currentItem: state.entities.currentItem,
 		currentUser: state.entities.users[state.session.id],
 		albumNavDropdownState: ownProps.albumNavDropdownState,
@@ -38,7 +37,7 @@ const mapDispatchToProps = (dispatch) => ({
 	displayPlaylist: (playlistId) => dispatch(displayPlaylist(playlistId)),
 	fetchPlaylists: (userId) => dispatch(fetchPlaylists(userId)),
 	toQueueView: (objToQueue) => dispatch(toQueueView(objToQueue)),
-	toPlayAlbum: (objToQueue) => dispatch(toPlayAlbum(objToQueue)),
+	toPlayView: (objToQueue) => dispatch(toPlayView(objToQueue)),
 });
 
 export default connect(mapStateToProps, mapDispatchToProps, null, {

--- a/frontend/components/albums/album_nav_submenu.jsx
+++ b/frontend/components/albums/album_nav_submenu.jsx
@@ -19,6 +19,7 @@ const AlbumNavSubmenu = ({
 	displayPlaylist,
 	fetchPlaylists,
 	toQueueView,
+	toPlayView,
 }) => {
 	const dropdownClass = depthLevel > 0 ? "dropdown-submenu" : "";
 
@@ -74,6 +75,7 @@ const AlbumNavSubmenu = ({
 						displayPlaylist={displayPlaylist}
 						fetchPlaylists={fetchPlaylists}
 						toQueueView={toQueueView}
+						toPlayView={toPlayView}
 					/>
 				);
 			})}

--- a/frontend/components/albums/album_nav_submenu.jsx
+++ b/frontend/components/albums/album_nav_submenu.jsx
@@ -6,7 +6,6 @@ const AlbumNavSubmenu = ({
 	history,
 	songs,
 	playlists,
-	selectedSong,
 	currentItem,
 	currentUser,
 	submenu,
@@ -56,7 +55,7 @@ const AlbumNavSubmenu = ({
 			{submenu.map((item, index) => {
 				return (
 					<SongCardDropdownItem // Else, create just a button
-						key={`${selectedSong.playlistedId}+${item.id}+${depthLevel}+"no-subm"`}
+						key={`"albumnav-submenu"+${depthLevel}+${item.id}`}
 						history={history}
 						currentItem={currentItem}
 						currentUser={currentUser}

--- a/frontend/components/albums/album_show_container.js
+++ b/frontend/components/albums/album_show_container.js
@@ -23,6 +23,7 @@ const mapStateToProps = (
 		currentUser: currentUser,
 		source: "album",
 		songCardDropdownItems: [
+			{ title: "Play album" },
 			{ title: "Add to queue" },
 			{
 				title: "Add to playlist",

--- a/frontend/components/albums/album_show_container.js
+++ b/frontend/components/albums/album_show_container.js
@@ -23,14 +23,14 @@ const mapStateToProps = (
 		currentUser: currentUser,
 		source: "album",
 		songCardDropdownItems: [
-			{ title: "Play album" },
-			{ title: "Add to queue" },
+			{ title: "Play album", id: `${crypto.randomUUID()}` },
+			{ title: "Add to queue", id: `${crypto.randomUUID()}` },
 			{
-				title: "Add to playlist",
+				title: "Add to playlist", id: `${crypto.randomUUID()}` ,
 				submenu: [
 					[
 						{
-							title: "Create new playlist",
+							title: "Create new playlist", id: `${crypto.randomUUID()}` ,
 						},
 						...playlists,
 						// Enclose array of playlists in an array since dropdown uses recursive .map function on items prop

--- a/frontend/components/albums/album_show_container.js
+++ b/frontend/components/albums/album_show_container.js
@@ -23,7 +23,6 @@ const mapStateToProps = (
 		currentUser: currentUser,
 		source: "album",
 		songCardDropdownItems: [
-			{ title: "Play album", id: `${crypto.randomUUID()}` },
 			{ title: "Add to queue", id: `${crypto.randomUUID()}` },
 			{
 				title: "Add to playlist", id: `${crypto.randomUUID()}` ,

--- a/frontend/components/artists/artist_page_dropdown.jsx
+++ b/frontend/components/artists/artist_page_dropdown.jsx
@@ -10,7 +10,6 @@ const ArtistPageDropdown = forwardRef(
 			history,
 			songs,
 			playlists,
-			selectedSong,
 			currentItem,
 			currentUser,
 			albumNavDropdownState,
@@ -21,13 +20,12 @@ const ArtistPageDropdown = forwardRef(
 			createNewPlaylisted,
 			createPlaylist,
 			displayPlaylist,
-			toQueueView,
-			toPlayAlbum,
 			fetchPlaylists,
+			toQueueView,
+			toPlayArtist,
 		},
 		ref
 	) => {
-		console.log("SELECTED SONG", selectedSong)
 		// Set local state for albumNavSubmenu
 		const [albumNavSubmenuState, setAlbumNavSubmenuState] = useState({
 			isOpen: false,
@@ -73,14 +71,14 @@ const ArtistPageDropdown = forwardRef(
 					item.submenu ? (
 						// If a submenu exists, create button for submenu title and pass submenu to AlbumNavSubmenu
 						<React.Fragment
-							key={`${selectedSong.playlistedId}+${depthLevel}+${item.title}+"w-submenu"`}
+							key={`"artistdropdown"+${item.id}+"w-submenu"`}
 						>
 							<button
 								className="song-card-dropdown-item"
 								onClick={toggleSubmenuAndPlaceDropdown}
 							>
 								{item.title}{" "}
-								<span key={`${selectedSong.playlistedId}`}>
+								<span key={`"item.id"+"w-submenu"`}>
 									&raquo;
 								</span>
 							</button>
@@ -88,7 +86,6 @@ const ArtistPageDropdown = forwardRef(
 								history={history}
 								songs={songs}
 								playlists={playlists}
-								selectedSong={selectedSong}
 								currentItem={currentItem}
 								currentUser={currentUser}
 								submenu={item.submenu}
@@ -111,13 +108,13 @@ const ArtistPageDropdown = forwardRef(
 						</React.Fragment>
 					) : (
 						<SongCardDropdownItem // Else, create just a button
-							key={`${selectedSong.playlistedId}+${item.id}+${depthLevel}+"no-subm"`}
+							key={`artistdropdown-subm-button" + ${item.id}`}
 							history={history}
 							currentItem={currentItem}
 							currentUser={currentUser}
 							playlists={playlists}
 							selectedIndex={index - 1} // Since the first item is "Create new playlist"
-							selectedSong={selectedSong}
+							selectedSong={songs}
 							updateSongCardDropdownState={
 								updateAlbumNavDropdownState
 							}

--- a/frontend/components/artists/artist_page_dropdown.jsx
+++ b/frontend/components/artists/artist_page_dropdown.jsx
@@ -22,7 +22,7 @@ const ArtistPageDropdown = forwardRef(
 			displayPlaylist,
 			fetchPlaylists,
 			toQueueView,
-			toPlayArtist,
+			toPlayView,
 		},
 		ref
 	) => {
@@ -104,6 +104,7 @@ const ArtistPageDropdown = forwardRef(
 								displayPlaylist={displayPlaylist}
 								fetchPlaylists={fetchPlaylists}
 								toQueueView={toQueueView}
+								toPlayView={toPlayView}
 							/>
 						</React.Fragment>
 					) : (
@@ -127,6 +128,7 @@ const ArtistPageDropdown = forwardRef(
 							displayPlaylist={displayPlaylist}
 							fetchPlaylists={fetchPlaylists}
 							toQueueView={toQueueView}
+							toPlayView={toPlayView}
 						/>
 					)
 				)}

--- a/frontend/components/artists/artist_page_dropdown.jsx
+++ b/frontend/components/artists/artist_page_dropdown.jsx
@@ -1,28 +1,50 @@
-import React, { useEffect, forwardRef } from "react";
+import React, { useState, useEffect, forwardRef } from "react";
 
-import ArtistPageDropdownItem from "./artist_page_dropdown_item";
+import SongCardDropdownItem from "../songs/song_card_dropdown_item";
+import AlbumNavSubmenu from "../albums/album_nav_submenu";
+import AlbumNavDropdown from "../albums/album_nav_dropdown";
 
 const ArtistPageDropdown = forwardRef(
 	(
-		{ // unused props will be for submenu refactoring
-			playlists,
-			allSongs,
-			handleAddToQueue,
+		{
 			history,
-			artistPageDropdownState,
-			toggleArtistPageDropdown,
+			songs,
+			playlists,
+			selectedSong,
+			currentItem,
+			currentUser,
+			albumNavDropdownState,
+			updateAlbumNavDropdownState,
 			items,
+			depthLevel,
+			removePlaylisted,
+			createNewPlaylisted,
+			createPlaylist,
+			displayPlaylist,
+			toQueueView,
+			toPlayAlbum,
+			fetchPlaylists,
 		},
 		ref
 	) => {
+		console.log("SELECTED SONG", selectedSong)
+		// Set local state for albumNavSubmenu
+		const [albumNavSubmenuState, setAlbumNavSubmenuState] = useState({
+			isOpen: false,
+		});
+		const updateAlbumNavSubmenuState = (newState) => {
+			setAlbumNavSubmenuState(newState);
+		};
+
+		// Add event listeners when menu is open; remove when menu is closed
 		useEffect(() => {
 			const whenMenuIsOpen = (event) => {
 				if (
-					artistPageDropdownState.isOpen &&
+					albumNavDropdownState.isOpen &&
 					ref?.current &&
 					!ref?.current?.contains(event.target)
 				) {
-					toggleArtistPageDropdown();
+					updateAlbumNavDropdownState({ isOpen: false });
 				}
 			};
 			document.addEventListener("mousedown", whenMenuIsOpen);
@@ -32,38 +54,86 @@ const ArtistPageDropdown = forwardRef(
 				document.removeEventListener("mousedown", whenMenuIsOpen);
 				document.removeEventListener("touchstart", whenMenuIsOpen);
 			};
-		}, [artistPageDropdownState]);
+		}, [albumNavDropdownState]);
 
-		const keepDropdownOpen = (event) => {
-			event.stopPropagation();
-			// prevents re-rendering of parent and keeps menu open
-
-			switch (
-				event.target.innerText // TODO: Fill out dropdown actions
-			) {
-				default:
-					null;
-			}
+		const toggleSubmenuAndPlaceDropdown = (e) => {
+			e.preventDefault();
+			setAlbumNavSubmenuState({ isOpen: !albumNavSubmenuState.isOpen });
 		};
 
 		return (
-			<>
-				<div className="dropdown-item artist-dropdown" ref={ref}>
-					{items.map((item, index) =>
-						item.submenu ? (
-							{
-								/* TODO: Implement submenu logic */
-							}
-						) : (
-							<ArtistPageDropdownItem
-								key={`${item.id} + ${index}`}
-								item={item}
-								handleAddToQueue={handleAddToQueue}
+			<div
+				className={`album-nav-dropdown dropdown-submenu ${
+					albumNavDropdownState.isOpen ? "show" : ""
+				}`}
+				data-dropdown
+				ref={ref}
+			>
+				{items.map((item, index) =>
+					item.submenu ? (
+						// If a submenu exists, create button for submenu title and pass submenu to AlbumNavSubmenu
+						<React.Fragment
+							key={`${selectedSong.playlistedId}+${depthLevel}+${item.title}+"w-submenu"`}
+						>
+							<button
+								className="song-card-dropdown-item"
+								onClick={toggleSubmenuAndPlaceDropdown}
+							>
+								{item.title}{" "}
+								<span key={`${selectedSong.playlistedId}`}>
+									&raquo;
+								</span>
+							</button>
+							<AlbumNavSubmenu
+								history={history}
+								songs={songs}
+								playlists={playlists}
+								selectedSong={selectedSong}
+								currentItem={currentItem}
+								currentUser={currentUser}
+								submenu={item.submenu}
+								submenuState={albumNavSubmenuState}
+								depthLevel={(depthLevel += 1)}
+								// dropdownPosition={dropdownPosition}
+								updateAlbumNavDropdownState={
+									updateAlbumNavDropdownState
+								}
+								updateAlbumNavSubmenuState={
+									updateAlbumNavSubmenuState
+								}
+								removePlaylisted={removePlaylisted}
+								createNewPlaylisted={createNewPlaylisted}
+								createPlaylist={createPlaylist}
+								displayPlaylist={displayPlaylist}
+								fetchPlaylists={fetchPlaylists}
+								toQueueView={toQueueView}
 							/>
-						)
-					)}
-				</div>
-			</>
+						</React.Fragment>
+					) : (
+						<SongCardDropdownItem // Else, create just a button
+							key={`${selectedSong.playlistedId}+${item.id}+${depthLevel}+"no-subm"`}
+							history={history}
+							currentItem={currentItem}
+							currentUser={currentUser}
+							playlists={playlists}
+							selectedIndex={index - 1} // Since the first item is "Create new playlist"
+							selectedSong={selectedSong}
+							updateSongCardDropdownState={
+								updateAlbumNavDropdownState
+							}
+							item={item}
+							depthLevel={depthLevel}
+							// dropdownPosition={dropdownPosition}
+							removePlaylisted={removePlaylisted}
+							createNewPlaylisted={createNewPlaylisted}
+							createPlaylist={createPlaylist}
+							displayPlaylist={displayPlaylist}
+							fetchPlaylists={fetchPlaylists}
+							toQueueView={toQueueView}
+						/>
+					)
+				)}
+			</div>
 		);
 	}
 );

--- a/frontend/components/artists/artist_page_dropdown_container.js
+++ b/frontend/components/artists/artist_page_dropdown_container.js
@@ -14,29 +14,30 @@ import { toQueueView, toPlayArtist } from "../../actions/now_playing_actions";
 import ArtistPageDropdown from "./artist_page_dropdown";
 
 const mapStateToProps = (state, ownProps) => {
+	;
 	return {
-		playlists: state.entities.playlists,
-		songs: state.entities.songs.allSongs,
-		currentItem: state.entities.currentItem,
-		history: ownProps.history,
-		artistPageDropdownState: ownProps.artistPageDropdownState,
 		ref: ownProps.ref,
+		history: ownProps.history,
+		songs: state.entities.songs,
+		playlists: state.entities.playlists,
+		currentItem: state.entities.currentItem,
+		currentUser: state.entities.users[state.session.id],
+		artistPageDropdownState: ownProps.artistPageDropdownState,
 		toggleArtistPageDropdown: ownProps.toggleArtistPageDropdown,
+		depthLevel: 0,
 		items: [
 			{ title: "Play artist", id: `${crypto.randomUUID()}` },
 			{
 				title: "Add to playlist",
 				id: `${crypto.randomUUID()}`,
 				submenu: [
-					[
-						{
-							title: "Create new playlist",
-							id: `${crypto.randomUUID()}`,
-						},
-						...state.entities.playlists,
-						// Enclose array of playlists in an array since
-						// dropdown uses recursive .map function on items prop
-					],
+					{
+						title: "Create new playlist",
+						id: `${crypto.randomUUID()}`,
+					},
+					...state.entities.playlists,
+					// Do not enclose array of playlists in an array since
+					// we are not using recursive function here
 				],
 			},
 			{

--- a/frontend/components/artists/artist_page_dropdown_container.js
+++ b/frontend/components/artists/artist_page_dropdown_container.js
@@ -13,19 +13,19 @@ const mapStateToProps = (state, ownProps) => {
 		ref: ownProps.ref,
 		toggleArtistPageDropdown: ownProps.toggleArtistPageDropdown,
 		items: [
-			// TODO: Implement adding artist songs to playlist
-			// {title: "Add to playlist",
-			// submenu: [
-			// 	[
-			// 		{
-			// 			title: "Create new playlist",
-			// 		},
-			// 		...playlists,
-			// 		// Enclose array of playlists in an array since
-			// 		// dropdown uses recursive .map function on items prop
-			// 	],
-			// ],
-			// },
+			{title: "Play artist"},
+			{title: "Add to playlist",
+			submenu: [
+				[
+					{
+						title: "Create new playlist",
+					},
+					...playlists,
+					// Enclose array of playlists in an array since
+					// dropdown uses recursive .map function on items prop
+				],
+			],
+			},
 			{
 				title: "Add to queue",
 				id: `${crypto.randomUUID()}`,

--- a/frontend/components/artists/artist_page_dropdown_container.js
+++ b/frontend/components/artists/artist_page_dropdown_container.js
@@ -18,7 +18,7 @@ const mapStateToProps = (state, ownProps) => {
 	return {
 		ref: ownProps.ref,
 		history: ownProps.history,
-		songs: state.entities.songs,
+		songs: state.entities.songs.allSongs,
 		playlists: state.entities.playlists,
 		currentItem: state.entities.currentItem,
 		currentUser: state.entities.users[state.session.id],

--- a/frontend/components/artists/artist_page_dropdown_container.js
+++ b/frontend/components/artists/artist_page_dropdown_container.js
@@ -4,27 +4,31 @@ import { toQueueArtist } from "../../actions/now_playing_actions";
 import ArtistPageDropdown from "./artist_page_dropdown";
 
 const mapStateToProps = (state, ownProps) => {
+	debugger
 	return {
 		playlists: state.entities.playlists,
-		allSongs: state.entities.songs.allSongs,
+		selectedSong: state.entities.songs.allSongs,
+		currentItem: state.entities.currentItem,
+		currentUser: state.entities.users[state.session.id],
 		handleAddToQueue: ownProps.handleAddToQueue,
 		history: ownProps.history,
 		artistPageDropdownState: ownProps.artistPageDropdownState,
 		ref: ownProps.ref,
 		toggleArtistPageDropdown: ownProps.toggleArtistPageDropdown,
 		items: [
-			{title: "Play artist"},
-			{title: "Add to playlist",
-			submenu: [
-				[
-					{
-						title: "Create new playlist",
-					},
-					...playlists,
-					// Enclose array of playlists in an array since
-					// dropdown uses recursive .map function on items prop
+			{ title: "Play artist" },
+			{
+				title: "Add to playlist",
+				submenu: [
+					[
+						{
+							title: "Create new playlist",
+						},
+						...state.entities.playlists,
+						// Enclose array of playlists in an array since
+						// dropdown uses recursive .map function on items prop
+					],
 				],
-			],
 			},
 			{
 				title: "Add to queue",

--- a/frontend/components/artists/artist_page_dropdown_container.js
+++ b/frontend/components/artists/artist_page_dropdown_container.js
@@ -9,7 +9,11 @@ import {
 	displayPlaylist,
 	fetchPlaylists,
 } from "../../actions/playlist_actions";
-import { toQueueView, toPlayArtist } from "../../actions/now_playing_actions";
+import {
+	toQueueView,
+	toPlayArtist,
+	toPlayView,
+} from "../../actions/now_playing_actions";
 
 import ArtistPageDropdown from "./artist_page_dropdown";
 
@@ -58,7 +62,7 @@ const mapDispatchToProps = (dispatch) => ({
 	displayPlaylist: (playlistId) => dispatch(displayPlaylist(playlistId)),
 	fetchPlaylists: (userId) => dispatch(fetchPlaylists(userId)),
 	toQueueView: (objToQueue) => dispatch(toQueueView(objToQueue)),
-	toPlayArtist: (objToQueue) => dispatch(toPlayArtist(objToQueue)),
+	toPlayView: (objToQueue) => dispatch(toPlayView(objToQueue)),
 });
 
 export default connect(mapStateToProps, mapDispatchToProps, null, {

--- a/frontend/components/artists/artist_page_dropdown_container.js
+++ b/frontend/components/artists/artist_page_dropdown_container.js
@@ -1,28 +1,37 @@
 import { connect } from "react-redux";
-import { toQueueArtist } from "../../actions/now_playing_actions";
+
+import {
+	removePlaylisted,
+	createNewPlaylisted,
+} from "../../actions/playlisted_actions";
+import {
+	createPlaylist,
+	displayPlaylist,
+	fetchPlaylists,
+} from "../../actions/playlist_actions";
+import { toQueueView, toPlayArtist } from "../../actions/now_playing_actions";
 
 import ArtistPageDropdown from "./artist_page_dropdown";
 
 const mapStateToProps = (state, ownProps) => {
-	debugger
 	return {
 		playlists: state.entities.playlists,
-		selectedSong: state.entities.songs.allSongs,
+		songs: state.entities.songs.allSongs,
 		currentItem: state.entities.currentItem,
-		currentUser: state.entities.users[state.session.id],
-		handleAddToQueue: ownProps.handleAddToQueue,
 		history: ownProps.history,
 		artistPageDropdownState: ownProps.artistPageDropdownState,
 		ref: ownProps.ref,
 		toggleArtistPageDropdown: ownProps.toggleArtistPageDropdown,
 		items: [
-			{ title: "Play artist" },
+			{ title: "Play artist", id: `${crypto.randomUUID()}` },
 			{
 				title: "Add to playlist",
+				id: `${crypto.randomUUID()}`,
 				submenu: [
 					[
 						{
 							title: "Create new playlist",
+							id: `${crypto.randomUUID()}`,
 						},
 						...state.entities.playlists,
 						// Enclose array of playlists in an array since
@@ -40,7 +49,15 @@ const mapStateToProps = (state, ownProps) => {
 };
 
 const mapDispatchToProps = (dispatch) => ({
-	toQueueArtist: (objToQueue) => dispatch(toQueueArtist(objToQueue)),
+	removePlaylisted: (playlistedId) =>
+		dispatch(removePlaylisted(playlistedId)),
+	createNewPlaylisted: (songId, playlistId) =>
+		dispatch(createNewPlaylisted(songId, playlistId)),
+	createPlaylist: (playlist) => dispatch(createPlaylist(playlist)),
+	displayPlaylist: (playlistId) => dispatch(displayPlaylist(playlistId)),
+	fetchPlaylists: (userId) => dispatch(fetchPlaylists(userId)),
+	toQueueView: (objToQueue) => dispatch(toQueueView(objToQueue)),
+	toPlayArtist: (objToQueue) => dispatch(toPlayArtist(objToQueue)),
 });
 
 export default connect(mapStateToProps, mapDispatchToProps, null, {

--- a/frontend/components/artists/artist_page_menu_bar.jsx
+++ b/frontend/components/artists/artist_page_menu_bar.jsx
@@ -66,9 +66,7 @@ const ArtistPageMenuBar = ({
 		<>
 			<div id="artist-play-button" onClick={handleButtonClick}>
 				{isPlaying &&
-				objToQueue.sourcedFrom === currentQueueSource.sourcedFrom &&
-				objToQueue.extractedUrlParams ===
-					currentQueueSource.extractedUrlParams ? (
+				objToQueue.sourcedFrom === currentQueueSource.sourcedFrom ? (
 					<MdOutlinePauseCircleFilled />
 				) : (
 					<MdOutlinePlayCircleFilled />

--- a/frontend/components/artists/artist_page_menu_bar.jsx
+++ b/frontend/components/artists/artist_page_menu_bar.jsx
@@ -77,11 +77,10 @@ const ArtistPageMenuBar = ({
 			</div>
 			{artistPageDropdownState.isOpen && (
 				<ArtistPageDropdownContainer
-					handleAddToQueue={handleAddToQueue}
 					history={history}
-					artistPageDropdownState={artistPageDropdownState}
+					albumNavDropdownState={artistPageDropdownState}
 					ref={dropdownRef}
-					toggleArtistPageDropdown={toggleArtistPageDropdown}
+					updateAlbumNavDropdownState={toggleArtistPageDropdown}
 				/>
 			)}
 		</>

--- a/frontend/components/artists/artist_page_menu_bar.jsx
+++ b/frontend/components/artists/artist_page_menu_bar.jsx
@@ -11,13 +11,13 @@ import {
 const ArtistPageMenuBar = ({
 	artistShowRef,
 	allSongs,
+	history,
 	isPlaying,
 	currentQueueSource,
 	toTogglePlay,
 	toQueueArtist,
 	toPlayArtist,
 	toPushPlay,
-	history,
 }) => {
 	const [artistPageDropdownState, setArtistPageDropdownState] = useState({
 		isOpen: false,

--- a/frontend/components/artists/artist_show.jsx
+++ b/frontend/components/artists/artist_show.jsx
@@ -13,7 +13,6 @@ const ArtistShow = ({
 	isPlaying,
 	currentQueueSource,
 	urlParams,
-	currentUser,
 	history,
 	displayArtist,
 	displayAlbum,

--- a/frontend/components/artists/artist_show.jsx
+++ b/frontend/components/artists/artist_show.jsx
@@ -51,13 +51,13 @@ const ArtistShow = ({
 						<ArtistPageMenuBar
 							artistShowRef={artistShowRef}
 							allSongs={allSongs}
+							history={history}
 							isPlaying={isPlaying}
 							currentQueueSource={currentQueueSource}
 							toTogglePlay={toTogglePlay}
 							toQueueArtist={toQueueArtist}
 							toPlayArtist={toPlayArtist}
 							toPushPlay={toPushPlay}
-							history={history}
 						/>
 					</div>
 					{albums?.length > 0 && (

--- a/frontend/components/songs/song_card_dropdown_item.jsx
+++ b/frontend/components/songs/song_card_dropdown_item.jsx
@@ -14,8 +14,9 @@ const SongCardDropdownItem = ({
 	createNewPlaylisted,
 	createPlaylist,
 	displayPlaylist,
-    fetchPlaylists,
+	fetchPlaylists,
 	toQueueView,
+	toPlayView,
 }) => {
 	let objToQueue;
 	let selectedPlaylist = playlists[selectedIndex];
@@ -28,6 +29,13 @@ const SongCardDropdownItem = ({
 			sourcedFrom: history.location.pathname,
 		};
 		return toQueueView(objToQueue);
+	};
+	const playNow = (selectedSongArr) => {
+		objToQueue = {
+			viewSongs: selectedSongArr,
+			sourcedFrom: history.location.pathname,
+		};
+		return toPlayView(objToQueue);
 	};
 	const addToPlaylist = async (selectedSongArr) => {
 		const promises = selectedSongArr.map((song) => {
@@ -65,6 +73,13 @@ const SongCardDropdownItem = ({
 		if (e.target.innerText === "Add to queue") {
 			updateSongCardDropdownState({ isOpen: false });
 			return addToQueue(selectedSong);
+		} else if (
+			e.target.innerText === "Play album" ||
+			e.target.innerText === "Play playlist" ||
+			e.target.innerText === "Play artist"
+		) {
+			updateSongCardDropdownState({ isOpen: false });
+			return playNow(selectedSong);
 		} else if (e.target.innerText === "Remove from this playlist") {
 			updateSongCardDropdownState({ isOpen: false });
 			return removePlaylisted(selectedSong[0].playlistedId);

--- a/frontend/components/songs/song_card_dropdown_item.jsx
+++ b/frontend/components/songs/song_card_dropdown_item.jsx
@@ -53,7 +53,7 @@ const SongCardDropdownItem = ({
 		let title =
 			selectedSongArr.length === 1
 				? selectedSongArr[0].title
-				: currentItem.title;
+				: currentItem.title || currentItem.name;
 		const newPlaylist = {
 			title: title,
 			description: "Please add a description",

--- a/frontend/components/songs/song_card_dropdown_item.jsx
+++ b/frontend/components/songs/song_card_dropdown_item.jsx
@@ -17,7 +17,6 @@ const SongCardDropdownItem = ({
     fetchPlaylists,
 	toQueueView,
 }) => {
-    console.log("currentUser", currentUser)
 	let objToQueue;
 	let selectedPlaylist = playlists[selectedIndex];
 	if (selectedSong.constructor !== Array) selectedSong = [selectedSong];
@@ -76,7 +75,6 @@ const SongCardDropdownItem = ({
 				fetchPlaylists();
 			}, 0);
 		} else if (depthLevel === 1) {
-            debugger
 			updateSongCardDropdownState({ isOpen: false });
 			addToPlaylist(selectedSong);
 		}

--- a/frontend/components/songs/song_card_dropdown_item.jsx
+++ b/frontend/components/songs/song_card_dropdown_item.jsx
@@ -67,7 +67,7 @@ const SongCardDropdownItem = ({
 			return addToQueue(selectedSong);
 		} else if (e.target.innerText === "Remove from this playlist") {
 			updateSongCardDropdownState({ isOpen: false });
-			return removePlaylisted(selectedSong.playlistedId);
+			return removePlaylisted(selectedSong[0].playlistedId);
 		} else if (e.target.innerText === "Create new playlist") {
 			updateSongCardDropdownState({ isOpen: false });
 			makeIntoPlaylist(selectedSong);

--- a/frontend/components/songs/song_card_dropdown_item.jsx
+++ b/frontend/components/songs/song_card_dropdown_item.jsx
@@ -24,7 +24,6 @@ const SongCardDropdownItem = ({
 
 	// Define all song actions
 	const addToQueue = (selectedSongArr) => {
-		debugger;
 		objToQueue = {
 			viewSongs: selectedSongArr,
 			sourcedFrom: history.location.pathname,
@@ -32,7 +31,6 @@ const SongCardDropdownItem = ({
 		return toQueueView(objToQueue);
 	};
 	const addToPlaylist = async (selectedSongArr) => {
-		debugger;
 		const promises = selectedSongArr.map((song) => {
 			return createNewPlaylisted(song.id, selectedPlaylist.id);
 		});
@@ -45,7 +43,6 @@ const SongCardDropdownItem = ({
 	};
 
 	const makeIntoPlaylist = async (selectedSongArr) => {
-		debugger;
 		let title =
 			selectedSongArr.length === 1
 				? selectedSongArr[0].title

--- a/frontend/reducers/now_playing_reducer.js
+++ b/frontend/reducers/now_playing_reducer.js
@@ -55,6 +55,7 @@ const nowPlayingReducer = (
 					sourcedFrom: action.sourcedFrom,
 				});
 			}
+			newPlayState.isPlaying = true;
 			console.log("NEW QUEUE", newPlayState.queue);
 			return newPlayState;
 		default:


### PR DESCRIPTION
- Adds "Play artist" and "Play album" options to ArtistPageDropdown & AlbumNavDropdown so user can override the current queue / currently playing song and play the current view (TODO from #105).
- Fixes bug where playlists were not populating in ArtistPageDropdown submenu for users to add an artist's song to a playlist (TODO from #96).
    - Adapts artist's songs for SongCardDropdownItem song actions by keying into artist's `allSongs`
- Fixes bug where SongCardDropdownItem was no longer working for SongCardDropdown (after SongCardDropdown was adapted for use with arrays).
- Fixes bug where user could create a new playlist from songs on AlbumShow view but not ArtistShow view
- Fixes React error where on some occasion, dropdown menu items did not have unique React keys.

<hr>
TO-DOS:

- [ ] Clarify component names
    - ArtistPageDropdown is currently reusing AlbumNavDropdown & AlbumNavSubmenu components for a non-recursive dropdown flow (in contrast to SongCardDropdown <> SongCardDropdownSubmenu <> SongCardItem recursive dropdown flow)
- [ ] Need to add "Play playlist" option to PlaylistNavDropdown