### PR TITLE
Extensive clean-up of history prop/unused props, logout, AlbumLink/ArtistLink, play functions, & PlaylistEditModal

### DIFF
--- a/app/assets/stylesheets/08-playlist-show.scss
+++ b/app/assets/stylesheets/08-playlist-show.scss
@@ -97,6 +97,8 @@
     align-items: center;
     padding: 25px 35px;
     gap: 25px;
+    flex: 0 0 auto;
+    height: 118px;
 }
 
 #playlist-play-button {
@@ -115,15 +117,22 @@
 }
 
 #playlist-dropdown-dots, #artist-dropdown-dots {
+    position: relative;
     font-size: 30px;
     color: rgba(247, 245, 242, 0.5);
 }
 
 .playlist-dropdown {
-    left: 440px;
-    top: 365px;
-    align-items: flex-start;
-    min-width: 140px;
+    font-size: 15px;
+    z-index: 2;
+    width: 150px;
+    height: auto;
+    padding: 3px;
+    background-color: #282828;
+    position: relative;
+    color: white;
+    border-radius: 4px;
+    box-shadow: 0 16px 24px rgba(0, 0, 0, 0.3), 0 6px 8px rgba(0, 0, 0, 0.2);
 }
 
 .playlist-dropdown-button {
@@ -136,6 +145,7 @@
     background: transparent;
     border: none;
     text-align: left;
+    z-index: 2;
 }
 
 button.playlist-dropdown-button:hover {

--- a/app/assets/stylesheets/09-playlist-edit-modal.scss
+++ b/app/assets/stylesheets/09-playlist-edit-modal.scss
@@ -18,6 +18,8 @@
     height: 385px;
     padding: 25px;
     box-shadow: 0 4px 4px rgba(0,0,0,.3);
+    display: flex;
+    flex-direction: column;
 }
 
 .modal-header {

--- a/app/assets/stylesheets/10-playlist-edit-form.scss
+++ b/app/assets/stylesheets/10-playlist-edit-form.scss
@@ -6,13 +6,18 @@
 }
 
 .edit-playlist-form {
-    display: flex;
-    justify-content: flex-start;
-    align-items: flex-start;
     font-size: 1.5rem;
     font-weight: 700;
     font-family: Trebuchet MS;
     color: white;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+}
+
+.edit-content {
+    width: 100%;
 }
 
 .edit-content input, .edit-content textarea {
@@ -26,17 +31,16 @@
     height: 40px;
     margin: 0px 5px 15px 5px;
     padding: 0 12px;
-    width: calc(475px - 180px - 24px - 22px);
+    width: 98%;
 }
 
 .edit-content textarea {
     padding: 12px 12px;
-    height: calc(180px - 82px);
-    margin-bottom: 0px;
+    height: 180px;
+    margin-bottom: 10px;
 }
 
 .save-button {
-    display: inline-block;
     font-size: 16px;
     font-family: 'Trebuchet MS', 'Lucida Sans Unicode', 'Lucida Grande', 'Lucida Sans', Arial, sans-serif;
     font-weight: 700;
@@ -48,22 +52,7 @@
     padding: 13px 31px;
     border-radius: 24px;
     border: 0px;
-    margin-top: 5px;
-    display: inline-block;
-    font-size: 16px;
-    font-family: 'Trebuchet MS', 'Lucida Sans Unicode', 'Lucida Grande', 'Lucida Sans', Arial, sans-serif;
-    font-weight: 700;
-    color: black;
-    text-decoration: none;
-    background-color: #ffffff;
-    width: 100px;
-    text-align: center;
-    padding: 13px 31px;
-    border-radius: 24px;
-    border: 0px;
-    margin-top: 5px;
-    margin-left: calc(100% - 100px - 5.5px); // Div width minus width of the button minus half of the left padding
-    // Padding is within the border, so need to use margin to space it out
+    align-self: center;
 }
 
 .edit-footer {

--- a/app/models/playlisted.rb
+++ b/app/models/playlisted.rb
@@ -1,5 +1,5 @@
 class Playlisted < ApplicationRecord
-    after_commit :update_playlist
+    after_create :update_playlist
     validates :playlist_id, :song_id, presence: true
 
     belongs_to :playlist,

--- a/frontend/actions/now_playing_actions.js
+++ b/frontend/actions/now_playing_actions.js
@@ -18,42 +18,42 @@ const pushPlay = () => ({
 });
 
 const queueArtist = (objToQueue) => ({
-	//{allSongs:arr, sourcedFrom:str, extractedUrlParams:numStr}
+	//{allSongs:arr, sourcedFrom:str}
 	type: QUEUE_ARTIST,
 	songs: objToQueue.allSongs,
 	sourcedFrom: objToQueue.sourcedFrom,
 });
 
 const queuePlaylist = (objToQueue) => ({
-	//{playlistSongs:arr, sourcedFrom:str, extractedUrlParams:numStr}
+	//{playlistSongs:arr, sourcedFrom:str}
 	type: QUEUE_PLAYLIST,
 	songs: objToQueue.playlistSongs,
 	sourcedFrom: objToQueue.sourcedFrom,
 });
 
 const queueAlbum = (objToQueue) => ({
-	//{albumSongs:arr, sourcedFrom:str, extractedUrlParams:numStr}
+	//{albumSongs:arr, sourcedFrom:str}
 	type: QUEUE_ALBUM,
 	songs: objToQueue.albumSongs,
 	sourcedFrom: objToQueue.sourcedFrom,
 });
 
 const queueView = (objToQueue) => ({
-	//{viewSongs:arr, sourcedFrom:str, extractedUrlParams:numStr}
+	//{viewSongs:arr, sourcedFrom:str}
 	type: QUEUE_VIEW,
 	songs: objToQueue.viewSongs,
 	sourcedFrom: objToQueue.sourcedFrom,
 });
 
 const playArtist = (objToQueue) => ({
-	//{allSongs:arr, sourcedFrom:str, extractedUrlParams:numStr}
+	//{allSongs:arr, sourcedFrom:str}
 	type: PLAY_ARTIST,
 	songs: objToQueue.allSongs,
 	sourcedFrom: objToQueue.sourcedFrom,
 });
 
 const playPlaylist = (objToQueue) => ({
-	//{playlistSongs:arr, sourcedFrom:str, extractedUrlParams:numStr}
+	//{playlistSongs:arr, sourcedFrom:str}
 	type: PLAY_PLAYLIST,
 	songs: objToQueue.playlistSongs,
 	sourcedFrom: objToQueue.sourcedFrom,
@@ -68,7 +68,7 @@ const playAlbum = (objToQueue) => ({
 
 const playView = (objToQueue) => {
 	return {
-	//{viewSongs:arr, sourcedFrom:str, extractedUrlParams:numStr}
+	//{viewSongs:arr, sourcedFrom:str}
 	type: PLAY_VIEW,
 	songs: objToQueue.viewSongs,
 	sourcedFrom: objToQueue.sourcedFrom,

--- a/frontend/components/albums/album_card.jsx
+++ b/frontend/components/albums/album_card.jsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { withRouter } from "react-router-dom";
 
 const AlbumCard = ({ album, 
     history,
@@ -32,4 +33,4 @@ const AlbumCard = ({ album,
     )
 }
 
-export default AlbumCard;
+export default withRouter(AlbumCard);

--- a/frontend/components/albums/album_dropdown.jsx
+++ b/frontend/components/albums/album_dropdown.jsx
@@ -6,11 +6,11 @@ import Submenu from "../shared/submenu";
 const AlbumDropdown = forwardRef(
 	(
 		{
-			history,
 			songs,
 			playlists,
 			currentItem,
 			currentUser,
+			history,
 			albumDropdownState,
 			updateAlbumDropdownState,
 			items,

--- a/frontend/components/albums/album_dropdown_container.js
+++ b/frontend/components/albums/album_dropdown_container.js
@@ -14,12 +14,12 @@ import AlbumDropdown from "./album_dropdown";
 
 const mapStateToProps = (state, ownProps) => {
 	return {
-		ref: ownProps.ref,
-		history: ownProps.history,
 		songs: state.entities.songs,
 		playlists: state.entities.playlists,
 		currentItem: state.entities.currentItem,
 		currentUser: state.entities.users[state.session.id],
+		ref: ownProps.ref,
+		history: ownProps.history,
 		albumDropdownState: ownProps.albumDropdownState,
 		updateAlbumDropdownState: ownProps.updateAlbumDropdownState,
 		items: ownProps.items,

--- a/frontend/components/albums/album_header.jsx
+++ b/frontend/components/albums/album_header.jsx
@@ -3,7 +3,6 @@ import React from 'react';
 import ArtistLink from '../artists/artist_link';
 
 const AlbumHeader = ({ album,
-  history,
 }) => {
 
   const { id,
@@ -32,8 +31,7 @@ const AlbumHeader = ({ album,
       </div>
       <div className="album-description">
         <h3>
-          <ArtistLink artist={albumArtist} currentArtist={null} 
-            history={history}/>
+          <ArtistLink artist={albumArtist} currentArtist={null} />
           &nbsp;• {genre} • {year} • {number} {songWord}, {hours} {mins} min
         </h3>
       </div>

--- a/frontend/components/albums/album_index.jsx
+++ b/frontend/components/albums/album_index.jsx
@@ -3,7 +3,6 @@ import AlbumCard from "./album_card";
 
 
 const AlbumIndex = ({ albums,
-    history,
     displayAlbum,
 }) => {
     
@@ -17,7 +16,6 @@ const AlbumIndex = ({ albums,
                 {albums.map( album => (
                     <AlbumCard key={`${album.id}+${album.title}`} 
                         album={album} 
-                        history={history}
                         displayAlbum={displayAlbum}
                     />
                 ))}

--- a/frontend/components/albums/album_link.jsx
+++ b/frontend/components/albums/album_link.jsx
@@ -3,28 +3,29 @@ import { withRouter } from "react-router-dom";
 
 const AlbumLink = ({
     album,
-    currentAlbum,
     history,
 }) => {
+	const { id, name } = album;
 
-    const { id,
-        name,
-    } = album;
+	const currentView = {
+		source: history.location.pathname.split("/")[1],
+		id: parseInt(history.location.pathname.split("/")[2]),
+	};
 
-    const handleClick = (e) => {
-        e.preventDefault();
-        return history.push(`/album/${id}`);
-    }
+	const handleClick = (e) => {
+		e.preventDefault();
+		return history.push(`/album/${id}`);
+	};
 
-    if (currentAlbum === null) {
-        return <a onClick={handleClick} className="artist-link">{name}</a>
-    } else {
-        if (name === currentAlbum.name) {
-            return <span>{name}</span>
-        } else {
-            return <a onClick={handleClick} className="artist-link">{name}</a>
-        }
-    }
+	if (currentView.source === "album" && currentView.id === id) {
+		return <span>{name}</span>;
+	} else {
+		return (
+			<a onClick={handleClick} className="artist-link">
+				{name}
+			</a>
+		);
+	}
 }
 
 export default withRouter(AlbumLink);

--- a/frontend/components/albums/album_link.jsx
+++ b/frontend/components/albums/album_link.jsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { withRouter } from "react-router-dom";
 
 const AlbumLink = ({
     album,
@@ -26,4 +27,4 @@ const AlbumLink = ({
     }
 }
 
-export default AlbumLink;
+export default withRouter(AlbumLink);

--- a/frontend/components/albums/album_menu_bar.jsx
+++ b/frontend/components/albums/album_menu_bar.jsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { withRouter } from "react-router-dom"; 
 import { useState, useEffect, useRef } from "react";
 
 import AlbumDropdownContainer from "./album_dropdown_container";
@@ -98,4 +99,4 @@ const AlbumMenuBar = ({
 	);
 };
 
-export default AlbumMenuBar;
+export default withRouter(AlbumMenuBar);

--- a/frontend/components/albums/album_show.jsx
+++ b/frontend/components/albums/album_show.jsx
@@ -8,9 +8,8 @@ const AlbumShow = ({
 	currentAlbum,
 	tracks,
 	playlists,
-	urlParams,
-	history,
 	currentUser,
+	urlParams,
 	isPlaying,
 	currentQueueSource,
 	source,
@@ -28,14 +27,15 @@ const AlbumShow = ({
 		rendered ? rendered.scrollTo(0, 0) : null;
 
 		return () => clearCurrent();
-	}, [urlParams]); // Will run whenever urlParams.id changes, otherwise ArtistShow doesn't re-render
+	}, [urlParams]); // Will run whenever urlParams.id changes, otherwise AlbumShow doesn't re-render
+	// Passing this down from currentView bc wrapping withRouter doesn't always trigger useEffect
 
 	const albumShowRef = useRef();
 
 	const albumShow = (
 		<div className="album-show" ref={albumShowRef}>
 			<div className="album-header">
-				<AlbumHeader album={currentAlbum} history={history} />
+				<AlbumHeader album={currentAlbum} />
 			</div>
 			<div className="album-menu">
 				<AlbumMenuBar
@@ -44,7 +44,6 @@ const AlbumShow = ({
 					currentQueueSource={currentQueueSource}
 					tracks={tracks}
 					playlists={playlists}
-					history={history}
 					toPlayAlbum={toPlayAlbum}
 					toPushPlay={toPushPlay}
 					toTogglePlay={toTogglePlay}
@@ -53,7 +52,6 @@ const AlbumShow = ({
 			<SongIndex
 				currentUser={currentUser}
 				songs={tracks}
-				history={history}
 				source={source}
 				songCardDropdownItems={songCardDropdownItems}
 				currentViewRef={albumShowRef}

--- a/frontend/components/albums/album_show_container.js
+++ b/frontend/components/albums/album_show_container.js
@@ -24,6 +24,7 @@ const mapStateToProps = (
 		urlParams: params,
 		source: "album",
 		songCardDropdownItems: [
+			{ title: "Play song", id: `${crypto.randomUUID()}` },
 			{ title: "Add to queue", id: `${crypto.randomUUID()}` },
 			{
 				title: "Add to playlist", id: `${crypto.randomUUID()}` ,

--- a/frontend/components/albums/album_show_container.js
+++ b/frontend/components/albums/album_show_container.js
@@ -12,17 +12,16 @@ const mapStateToProps = (
 	// from state
 	{ entities: { currentItem, songs, playlists, nowPlaying} },
 	// from ownProps
-	{ params, history, currentUser }
+	{ currentUser, params }
 ) => {
 	return {
 		currentAlbum: currentItem,
 		tracks: songs,
 		playlists: playlists,
-		urlParams: params,
-		history: history,
 		currentUser: currentUser,
 		isPlaying: nowPlaying.isPlaying,
 		currentQueueSource: nowPlaying.queueSources[0],
+		urlParams: params,
 		source: "album",
 		songCardDropdownItems: [
 			{ title: "Add to queue", id: `${crypto.randomUUID()}` },

--- a/frontend/components/artists/artist_card.jsx
+++ b/frontend/components/artists/artist_card.jsx
@@ -1,9 +1,8 @@
 import React from "react";
-
+import { withRouter } from "react-router-dom";
 
 const ArtistCard = ({
     artist,
-    urlParams,
     history,
     displayArtist,
 }) => {
@@ -31,4 +30,4 @@ const ArtistCard = ({
     )
 }
 
-export default ArtistCard;
+export default withRouter(ArtistCard);

--- a/frontend/components/artists/artist_dropdown_container.js
+++ b/frontend/components/artists/artist_dropdown_container.js
@@ -20,7 +20,6 @@ import ArtistDropdown from "./artist_dropdown";
 const mapStateToProps = (state, ownProps) => {
 	return {
 		ref: ownProps.ref,
-		history: ownProps.history,
 		songs: state.entities.songs.allSongs,
 		playlists: state.entities.playlists,
 		currentItem: state.entities.currentItem,

--- a/frontend/components/artists/artist_index.jsx
+++ b/frontend/components/artists/artist_index.jsx
@@ -3,9 +3,6 @@ import ArtistCard from "./artist_card";
 
 const ArtistIndex = ({
     artists,
-    params,
-    history,
-    path,
     fetchArtists,
     displayArtist,
 }) => {
@@ -18,8 +15,6 @@ const ArtistIndex = ({
               <ArtistCard
                   key={`${artist.name + "ind"}`}
                   artist={artist}
-                  urlParams={params}
-                  history={history}
                   displayArtist={displayArtist}
               />
           ))

--- a/frontend/components/artists/artist_index_container.js
+++ b/frontend/components/artists/artist_index_container.js
@@ -3,15 +3,12 @@ import ArtistIndex from "./artist_index";
 import { fetchArtists, displayArtist } from "../../actions/artist_actions";
 
 const mapStateToProps = ({ entities: { artists } }, ownProps) => ({
-    artists: Object.values(artists),
-    params: ownProps.params,
-    history: ownProps.history,
-    path: ownProps.path,
+	artists: Object.values(artists),
 });
 
 const mapDispatchToProps = (dispatch) => ({
-    fetchArtists: () => dispatch(fetchArtists()),
-    displayArtist: (artistId) => dispatch(displayArtist(artistId)),
+	fetchArtists: () => dispatch(fetchArtists()),
+	displayArtist: (artistId) => dispatch(displayArtist(artistId)),
 });
 
 export default connect(mapStateToProps, mapDispatchToProps)(ArtistIndex);

--- a/frontend/components/artists/artist_link.jsx
+++ b/frontend/components/artists/artist_link.jsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { withRouter } from "react-router-dom";
 
 const ArtistLink = ({
     artist,
@@ -26,4 +27,4 @@ const ArtistLink = ({
     }
 }
 
-export default ArtistLink;
+export default withRouter(ArtistLink);

--- a/frontend/components/artists/artist_link.jsx
+++ b/frontend/components/artists/artist_link.jsx
@@ -5,7 +5,6 @@ const ArtistLink = ({
     artist,
     history,
 }) => {
-
     const { id,
         name,
     } = artist;

--- a/frontend/components/artists/artist_link.jsx
+++ b/frontend/components/artists/artist_link.jsx
@@ -3,7 +3,6 @@ import { withRouter } from "react-router-dom";
 
 const ArtistLink = ({
     artist,
-    currentArtist,
     history,
 }) => {
 
@@ -11,19 +10,24 @@ const ArtistLink = ({
         name,
     } = artist;
 
+    const currentView = {
+		source: history.location.pathname.split("/")[1],
+		id: parseInt(history.location.pathname.split("/")[2]),
+	};
+
     const handleClick = (e) => {
         e.preventDefault();
         return history.push(`/artist/${id}`);
     }
 
-    if (currentArtist === null) {
-        return <a onClick={handleClick} className="artist-link">{name}</a>
+    if (currentView.source === "artist" && currentView.id === id) {
+        return <span>{name}</span>;
     } else {
-        if (name === currentArtist.name) {
-            return <span>{name}</span>
-        } else {
-            return <a onClick={handleClick} className="artist-link">{name}</a>
-        }
+        return (
+            <a onClick={handleClick} className="artist-link">
+                {name}
+            </a>
+        );
     }
 }
 

--- a/frontend/components/artists/artist_menu_bar.jsx
+++ b/frontend/components/artists/artist_menu_bar.jsx
@@ -75,7 +75,6 @@ const ArtistMenuBar = ({
 			</div>
 			{artistDropdownState.isOpen && (
 				<ArtistDropdownContainer
-					history={history}
 					artistDropdownState={artistDropdownState}
 					ref={dropdownRef}
 					updateArtistDropdownState={updateArtistDropdownState}

--- a/frontend/components/artists/artist_menu_bar.jsx
+++ b/frontend/components/artists/artist_menu_bar.jsx
@@ -1,4 +1,5 @@
 import React, { useRef, useState, useEffect } from "react";
+import { withRouter } from "react-router-dom";
 import ArtistDropdownContainer from "./artist_dropdown_container";
 
 import { RxDotsHorizontal } from "react-icons/rx";
@@ -76,6 +77,7 @@ const ArtistMenuBar = ({
 			{artistDropdownState.isOpen && (
 				<ArtistDropdownContainer
 					artistDropdownState={artistDropdownState}
+					history={history}
 					ref={dropdownRef}
 					updateArtistDropdownState={updateArtistDropdownState}
 				/>
@@ -84,4 +86,4 @@ const ArtistMenuBar = ({
 	);
 };
 
-export default ArtistMenuBar;
+export default withRouter(ArtistMenuBar);

--- a/frontend/components/artists/artist_show.jsx
+++ b/frontend/components/artists/artist_show.jsx
@@ -1,5 +1,4 @@
 import React, { useEffect, useRef } from "react";
-import { withRouter } from "react-router-dom";
 
 import ArtistHeader from "./artist_header";
 import AlbumIndex from "../albums/album_index";
@@ -14,7 +13,6 @@ const ArtistShow = ({
 	isPlaying,
 	currentQueueSource,
 	urlParams,
-	history, // prop object from withRouter
 	displayArtist,
 	displayAlbum,
 	toTogglePlay,
@@ -53,7 +51,6 @@ const ArtistShow = ({
 							allSongs={allSongs}
 							isPlaying={isPlaying}
 							currentQueueSource={currentQueueSource}
-							history={history}
 							toTogglePlay={toTogglePlay}
 							toPlayArtist={toPlayArtist}
 							toPushPlay={toPushPlay}
@@ -80,4 +77,4 @@ const ArtistShow = ({
 	return currentArtist.photoUrl && artistShow;
 };
 
-export default withRouter(ArtistShow);
+export default ArtistShow;

--- a/frontend/components/artists/artist_show.jsx
+++ b/frontend/components/artists/artist_show.jsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useRef } from "react";
+import { withRouter } from "react-router-dom";
 
 import ArtistHeader from "./artist_header";
 import AlbumIndex from "../albums/album_index";
@@ -13,7 +14,7 @@ const ArtistShow = ({
 	isPlaying,
 	currentQueueSource,
 	urlParams,
-	history,
+	history, // prop object from withRouter
 	displayArtist,
 	displayAlbum,
 	toTogglePlay,
@@ -31,6 +32,7 @@ const ArtistShow = ({
 			clearCurrent();
 		};
 	}, [urlParams]); // Will run whenever urlParams.id changes, otherwise ArtistShow doesn't re-render
+	// Passing this down from currentView bc wrapping withRouter doesn't always trigger useEffect
 
 	const artistShowRef = useRef();
 	const artistShow = (
@@ -49,9 +51,9 @@ const ArtistShow = ({
 						<ArtistMenuBar
 							artistShowRef={artistShowRef}
 							allSongs={allSongs}
-							history={history}
 							isPlaying={isPlaying}
 							currentQueueSource={currentQueueSource}
+							history={history}
 							toTogglePlay={toTogglePlay}
 							toPlayArtist={toPlayArtist}
 							toPushPlay={toPushPlay}
@@ -60,14 +62,12 @@ const ArtistShow = ({
 					{albums?.length > 0 && (
 						<AlbumIndex
 							albums={albums}
-							history={history}
 							displayAlbum={displayAlbum}
 						/>
 					)}
 					{collabSongs?.length > 0 && (
 						<CollabSongIndex
 							songs={collabSongs}
-							history={history}
 							displayAlbum={displayAlbum}
 							currentArtist={currentArtist}
 						/>
@@ -80,4 +80,4 @@ const ArtistShow = ({
 	return currentArtist.photoUrl && artistShow;
 };
 
-export default ArtistShow;
+export default withRouter(ArtistShow);

--- a/frontend/components/artists/artist_show_container.js
+++ b/frontend/components/artists/artist_show_container.js
@@ -19,9 +19,8 @@ const mapStateToProps = (state, ownProps) => {
 		collabSongs: state.entities.songs.collabSongs,
 		isPlaying: state.entities.nowPlaying.isPlaying,
 		currentQueueSource: state.entities.nowPlaying.queueSources[0],
-		urlParams: ownProps.params,
 		currentUser: ownProps.currentUser,
-		history: ownProps.history,
+		urlParams: ownProps.params,
 	};
 };
 

--- a/frontend/components/home/home.jsx
+++ b/frontend/components/home/home.jsx
@@ -2,18 +2,14 @@ import React from "react";
 
 import ArtistIndexContainer from "../artists/artist_index_container";
 
-const Home = ({ params, history, path }) => {
+const Home = () => {
 	return (
 		<div className="home">
 			<div className="home-header">Your Versify</div>
 			<div className="artist-index-header">
 				<h1>All Artists</h1>
 			</div>
-			<ArtistIndexContainer
-				params={params}
-				history={history}
-				path={path}
-			/>
+			<ArtistIndexContainer />
 		</div>
 	);
 };

--- a/frontend/components/home/home_container.jsx
+++ b/frontend/components/home/home_container.jsx
@@ -2,10 +2,8 @@ import { connect } from "react-redux";
 
 import Home from "./home";
 
-const mapStateToProps = (state, ownProps) => ({
-    params: ownProps.params,
-    history: ownProps.history,
-});
+const mapStateToProps = (state, ownProps) => ({});
 
 const mapDispatchToProps = (dispatch) => ({});
+
 export default connect(mapStateToProps, null)(Home);

--- a/frontend/components/nav_bar/nav_bar_main.jsx
+++ b/frontend/components/nav_bar/nav_bar_main.jsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { withRouter } from "react-router-dom";
 import { MdKeyboardArrowDown, MdKeyboardArrowUp } from "react-icons/md";
 
 import SearchBar from "./searchbar";
@@ -68,4 +69,4 @@ class NavBarMain extends React.Component {
 	}
 }
 
-export default NavBarMain;
+export default withRouter(NavBarMain);

--- a/frontend/components/page/current_view.jsx
+++ b/frontend/components/page/current_view.jsx
@@ -7,47 +7,38 @@ import AlbumShowContainer from "../albums/album_show_container.js";
 
 const CurrentView = (props) => {
     const currentViewType = () => {
-        const { path, params, currentUser, history } = props;
+        const { path, params, currentUser } = props;
 
         switch (path) {
             case "/home":
                 return (
                     <HomeContainer
-                        params={params}
-                        history={history}
-                        path={path}
                     />
                 );
             case "/playlist/:id":
                 return (
-                    <PlaylistShowContainer
-                        params={params}
-                        currentUser={currentUser}
-                        history={history}
-                    />
-                );
+					<PlaylistShowContainer
+						currentUser={currentUser}
+						params={params}
+					/>
+				);
             case "/artist/:id":
                 return (
                     <ArtistShowContainer
-                        params={params}
                         currentUser={currentUser}
-                        history={history}
+                        params={params}
                     />
                 );
             case "/album/:id":
                 return (
-                    <AlbumShowContainer
-                        params={params}
-                        currentUser={currentUser}
-                        history={history}
-                    />
-                );
+					<AlbumShowContainer
+						currentUser={currentUser}
+						params={params}
+					/>
+				);
             default:
                 return (
                     <HomeContainer
-                        params={params}
-                        history={history}
-                        path={path}
                     />
                 );
         }

--- a/frontend/components/page/page.jsx
+++ b/frontend/components/page/page.jsx
@@ -6,7 +6,6 @@ import CurrentViewContainer from "./current_view_container";
 import PlayerContainer from "../player/player_container";
 
 const Page = ({
-	history,
 	params,
 	path,
 	currentUser,
@@ -15,11 +14,9 @@ const Page = ({
 }) => {
 	return (
 		<div className="page-container">
-			<NavBarMainContainer history={history} />
+			<NavBarMainContainer />
 			<div className="page-body">
 				<SidebarContainer
-					history={history}
-					path={path}
 					currentUser={currentUser}
 					errors={errors}
 				/>
@@ -28,14 +25,10 @@ const Page = ({
 						currentUser={currentUser}
 						params={params}
 						path={path}
-						history={history}
 					/>
 				</div>
 			</div>
 			<PlayerContainer
-				params={params}
-				path={path}
-				history={history}
 			/>
 		</div>
 	);

--- a/frontend/components/player/now_playing_info.jsx
+++ b/frontend/components/player/now_playing_info.jsx
@@ -20,6 +20,7 @@ const NowPlayingInfo = ({
 		};
 	}
 	const { title, albumId, albumImageUrl, songArtist } = track;
+
 	useEffect(() => {
 		updateTrackProgress(audioRef.current.currentTime);
 	}, [isPlaying]);
@@ -40,8 +41,6 @@ const NowPlayingInfo = ({
 									id: track.albumId,
 									name: title ,
 								}}
-								currentAlbum={null}
-								history={history}
 							/>
 						</div>
 						<div className="now-playing-artist">

--- a/frontend/components/player/now_playing_info.jsx
+++ b/frontend/components/player/now_playing_info.jsx
@@ -46,8 +46,6 @@ const NowPlayingInfo = ({
 						<div className="now-playing-artist">
 							<ArtistLinkContainer
 								artist={songArtist}
-								currentArtist={null}
-								history={history}
 							/>
 						</div>
 					</div>

--- a/frontend/components/player/player.jsx
+++ b/frontend/components/player/player.jsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useRef, useState } from "react";
+import { withRouter } from "react-router-dom";
 import NowPlayingInfo from "./now_playing_info";
 import PlayingControls from "./playing_controls";
 
@@ -126,4 +127,4 @@ const Player = ({
 	);
 };
 
-export default Player;
+export default withRouter(Player);

--- a/frontend/components/player/player.jsx
+++ b/frontend/components/player/player.jsx
@@ -30,10 +30,13 @@ const Player = ({
 	useEffect(() => {
 		audioSrc = currentTrack ? currentTrack.audioUrl : "";
 		audioRef.current.src = audioSrc;
+
+		return () => {
+			audioRef.current?.pause();
+		}
 	}, [currentTrack]);
 
 	// Safely play audio only when it is loaded
-
 	const tryPlay = () => {
 		if (audioRef.current.readyState === 4) {
 			audioRef.current.play();
@@ -56,7 +59,18 @@ const Player = ({
 		};
 	}, [isPlaying]);
 
-	// Set up behavior when changing tracks
+	// Behavior when track ends
+	audioRef.current?.addEventListener(
+		"ended",
+		() => {
+			if (tracks.length > 1) {
+				setTrackIndex(trackIndex + 1);
+			}
+		},
+		false
+	);
+
+	// Behavior when changing tracks
 	const afterFirstRender = useRef(false); // prevent auto-play
 	useEffect(() => {
 		if (isPlaying && afterFirstRender.current) {
@@ -69,6 +83,11 @@ const Player = ({
 		}
 		if (!afterFirstRender) afterFirstRender.current = true;
 	}, [trackIndex]);
+
+	// Behavior when user leaves the window
+	window.addEventListener("unload", () => {
+		audioElement.pause();
+	});
 
 	// Create PlayingControls functions
 	const toPrevTrack = () => {

--- a/frontend/components/player/player_container.js
+++ b/frontend/components/player/player_container.js
@@ -15,9 +15,6 @@ const mapStateToProps = (state, ownProps) => {
 		songs: state.entities.songs, // songs of the current view
 		isPlaying: state.entities.nowPlaying.isPlaying,
 		hasQueue: state.entities.nowPlaying.queue.length > 0,
-		// matchObj is a prop passed down by AuthRoute
-		// matchObj = {params, path, url} as keys
-		history: ownProps.history,
 	};
 };
 

--- a/frontend/components/player/playing_controls.jsx
+++ b/frontend/components/player/playing_controls.jsx
@@ -26,8 +26,10 @@ const PlayingControls = ({
 			objToQueue.viewSongs = objToQueue.viewSongs.allSongs;
 		}
 		if (!hasQueue) {
-			toPlayView(objToQueue);
-			toPushPlay();
+			if (objToQueue?.viewSongs?.length > 0) {
+				toPlayView(objToQueue);
+				toPushPlay();
+			}
 		} else {
 			togglePlay();
 		}

--- a/frontend/components/playlists/playlist_edit_form.jsx
+++ b/frontend/components/playlists/playlist_edit_form.jsx
@@ -27,7 +27,8 @@ const PlaylistEditForm = ({ currentPlaylist, editPlaylist }) => {
     return (
         <>
             <form className="edit-playlist-form">
-                <div className="playlist-art-edit"></div>
+                {/* <div className="playlist-art-edit"></div> */}
+                {/* TODO: Enable uploading and storing user's images for playlist */}
                 <div className="edit-content">
                     <label htmlFor="title">
                         <input type="text" 
@@ -49,14 +50,14 @@ const PlaylistEditForm = ({ currentPlaylist, editPlaylist }) => {
                     </label>
                     <br />
                 </div>
+                <button className="save-button" onClick={handleSubmit}>
+                    Save
+                </button>
             </form>
-            <button className="save-button" onClick={handleSubmit}>
-                Save
-            </button>
-            <div className="edit-footer">
+            {/* <div className="edit-footer">
                 By proceeding, you agree to give this Spotify clone access to the 
                 image you choose to upload. Please make sure you have the right to upload the image.
-            </div>
+            </div> */}
         </>
     )
 }

--- a/frontend/components/playlists/playlist_index.jsx
+++ b/frontend/components/playlists/playlist_index.jsx
@@ -5,19 +5,15 @@ import SidebarPlaylistButton from '../sidebar/sidebar_playlist_button'
 
 // PlaylistIndex is simple enough to convert to functional component
 const PlaylistIndex = (props) => {
-
     const { fetchPlaylists,
         displayPlaylist,
         playlists,
         currentPlaylist,
-        currentUsername,
-        path,
-        history,
     } = props;
 
     useEffect( () => {
         fetchPlaylists();
-    }, [path]);
+    }, []);
 
     return (
         playlists.length === 0 ?
@@ -27,7 +23,7 @@ const PlaylistIndex = (props) => {
             :
             <div className="playlist-index">
                 {playlists.map((playlist) => (
-                    <SidebarPlaylistButton key={`${playlist.id} + ${playlist.title}`} title={playlist.title} playlistId={playlist.id} displayPlaylist={displayPlaylist} history={history} />))
+                    <SidebarPlaylistButton key={`${playlist.id} + ${playlist.title}`} title={playlist.title} playlistId={playlist.id} displayPlaylist={displayPlaylist}  />))
                 }
             </div>
     )

--- a/frontend/components/playlists/playlist_nav.jsx
+++ b/frontend/components/playlists/playlist_nav.jsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useRef } from "react";
+import { withRouter } from "react-router-dom";
 import PlaylistNavDropdown from "./playlist_nav_dropdown";
 
 import { RxDotsHorizontal } from "react-icons/rx";
@@ -98,4 +99,4 @@ const PlaylistNav = ({
 	);
 };
 
-export default PlaylistNav;
+export default withRouter(PlaylistNav);

--- a/frontend/components/playlists/playlist_nav.jsx
+++ b/frontend/components/playlists/playlist_nav.jsx
@@ -56,8 +56,10 @@ const PlaylistNav = ({
 		) {
 			toTogglePlay();
 		} else {
-			toPlayPlaylist(objToQueue);
-			toPushPlay();
+			if (objToQueue.playlistSongs?.length > 0) {
+				toPlayPlaylist(objToQueue);
+				toPushPlay();
+			}
 		}
 	};
 
@@ -65,7 +67,7 @@ const PlaylistNav = ({
 		<>
 			<div id="artist-play-button" onClick={handleButtonClick}>
 				{isPlaying &&
-				objToQueue.sourcedFrom === currentQueueSource.sourcedFrom ? (
+				objToQueue.sourcedFrom === currentQueueSource?.sourcedFrom ? (
 					<MdOutlinePauseCircleFilled />
 				) : (
 					<MdOutlinePlayCircleFilled />

--- a/frontend/components/playlists/playlist_nav_dropdown.jsx
+++ b/frontend/components/playlists/playlist_nav_dropdown.jsx
@@ -72,7 +72,7 @@ const PlaylistNavDropdown = ({
 				openPlaylistEditModal();
 				return console.log("OPEN EDIT MODAL");
 			case "Delete":
-				destroyPlaylist(currentPlaylist.id).then(fetchPlaylists());
+				destroyPlaylist(currentPlaylist.id);
 				return history.push("/home");
 			case "Add to queue":
 				addToQueue(objToQueue);

--- a/frontend/components/playlists/playlist_nav_dropdown.jsx
+++ b/frontend/components/playlists/playlist_nav_dropdown.jsx
@@ -41,12 +41,24 @@ const PlaylistNavDropdown = ({
 		};
 	}, []);
 
-	const playNow = (songsArr) => {
-		objToQueue = {
-			viewSongs: songsArr,
-			sourcedFrom: history.location.pathname,
-		};
-		return toPlayView(objToQueue);
+	const addToQueue = (selectedSongArr) => {
+		if (selectedSongArr?.length > 0) {
+			objToQueue = {
+				viewSongs: selectedSongArr,
+				sourcedFrom: history.location.pathname,
+			};
+			return toQueueView(objToQueue);
+		}
+	};
+
+	const playNow = (selectedSongArr) => {
+		if (selectedSongArr?.length > 0) {
+			objToQueue = {
+				viewSongs: selectedSongArr,
+				sourcedFrom: history.location.pathname,
+			};
+			return toPlayView(objToQueue);
+		}
 	};
 
 	const keepDropdownOpen = (event) => {
@@ -63,7 +75,7 @@ const PlaylistNavDropdown = ({
 				destroyPlaylist(currentPlaylist.id).then(fetchPlaylists());
 				return history.push("/home");
 			case "Add to queue":
-				toQueuePlaylist(objToQueue);
+				addToQueue(objToQueue);
                 return closePlaylistNavDropdown();
 			default:
 				null;

--- a/frontend/components/playlists/playlist_show.jsx
+++ b/frontend/components/playlists/playlist_show.jsx
@@ -11,7 +11,6 @@ const PlaylistShow = ({
 	playlistSongs,
 	urlParams,
 	currentUser,
-	history,
 	source,
 	songCardDropdownItems,
 	displayPlaylist,
@@ -45,8 +44,6 @@ const PlaylistShow = ({
 				<PlaylistNav
 					currentPlaylist={currentPlaylist}
 					playlistSongs={playlistSongs}
-					urlParams={urlParams}
-					history={history}
 					{...props}
 				/>
 			</div>
@@ -54,7 +51,6 @@ const PlaylistShow = ({
 				currentUser={currentUser}
 				playlists={playlists}
 				songs={playlistSongs}
-				history={history}
 				source={source}
 				songCardDropdownItems={songCardDropdownItems}
 				currentViewRef={playlistShowRef}

--- a/frontend/components/playlists/playlist_show_container.js
+++ b/frontend/components/playlists/playlist_show_container.js
@@ -41,6 +41,9 @@ const mapStateToProps = (
 		source: "playlist",
 		songCardDropdownItems: [
 			{
+				title: "Play song"
+			},
+			{
 				title: "Add to queue",
 			},
 			{

--- a/frontend/components/playlists/playlist_show_container.js
+++ b/frontend/components/playlists/playlist_show_container.js
@@ -26,7 +26,7 @@ const mapStateToProps = (
 	// from state
 	{ ux, entities: { currentItem, playlists, songs, nowPlaying } },
 	// from ownProps
-	{ params, history, currentUser }
+	{ currentUser, params }
 ) => {
 	return {
 		currentPlaylist: currentItem,
@@ -36,9 +36,8 @@ const mapStateToProps = (
 		currentQueueSource: nowPlaying.queueSources[0],
 		playlistNavDropdownState: ux.playlistNavDropdown,
 		playlistEditModalState: ux.playlistEditModal,
-		urlParams: params,
 		currentUser: currentUser,
-		history: history,
+		urlParams: params,
 		source: "playlist",
 		songCardDropdownItems: [
 			{

--- a/frontend/components/sidebar/sidebar.jsx
+++ b/frontend/components/sidebar/sidebar.jsx
@@ -1,5 +1,5 @@
 import React, { useEffect } from "react";
-
+import { withRouter } from "react-router-dom";
 import { AiFillHome } from "react-icons/ai";
 import { FaSearch } from "react-icons/fa";
 import { MdOutlineAddBox } from "react-icons/md";
@@ -12,7 +12,6 @@ const Sidebar = (props) => {
         createPlaylist,
         fetchPlaylists,
         playlists,
-        path,
         history,
         currentUser,
         errors,
@@ -24,7 +23,6 @@ const Sidebar = (props) => {
     // )
 
     // const handleDropdown = useMemo( () => <playlistNavDropdown
-    // playlistNavDropdown={playlistNavDropdown} />, [playlistNavDropdown] )
 
     const handleSubmitCreate = (e) => {
         e.preventDefault();
@@ -68,12 +66,9 @@ const Sidebar = (props) => {
 
             <div className="line"></div>
             <PlaylistIndexContainer currentUser={currentUser} 
-                history={history} path={path}/>
-            {/* {playlistIndexRender} */}
-                {/* Only re-render Playlist#Index of the playlists slice of state changes */}
-                {/* pass currentUser through as props to keep on refresh */}
+                history={history}/>
         </section>
     );
 };
 
-export default Sidebar;
+export default withRouter(Sidebar);

--- a/frontend/components/sidebar/sidebar_container.js
+++ b/frontend/components/sidebar/sidebar_container.js
@@ -8,8 +8,6 @@ import { fetchPlaylists,
 const mapStateToProps = (state, ownProps) => ({
     playlists: state.entities.playlists,
     currentUser: ownProps.currentUser,     // pass this through as props to keep on refresh
-    path: ownProps.path,
-    history: ownProps.history,
 })
 
 const mapDispatchToProps = (dispatch) => ({

--- a/frontend/components/sidebar/sidebar_playlist_button.jsx
+++ b/frontend/components/sidebar/sidebar_playlist_button.jsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { withRouter } from "react-router-dom";
 
 const SidebarPlaylistButton = (props) => {
     const { title, playlistId, history, displayPlaylist } = props;
@@ -15,4 +16,4 @@ const SidebarPlaylistButton = (props) => {
     );
 };
 
-export default SidebarPlaylistButton;
+export default withRouter(SidebarPlaylistButton);

--- a/frontend/components/songs/collab_card.jsx
+++ b/frontend/components/songs/collab_card.jsx
@@ -18,7 +18,7 @@ const CollabCard = ({
     } =  song;
 
     const collabArtistNames = collabArtists.map(artist => {
-        return <div className="artist-name" key={`${artist.name}+"collab"+${artist.id}`}><ArtistLinkContainer artist={artist} currentArtist={currentArtist}/>, </div>
+        return <div className="artist-name" key={`${artist.name}+"collab"+${artist.id}`}><ArtistLinkContainer artist={artist}/>, </div>
     })
 
     const songArtistName = <ArtistLinkContainer artist={songArtist} currentArtist={currentArtist}/>

--- a/frontend/components/songs/collab_card.jsx
+++ b/frontend/components/songs/collab_card.jsx
@@ -48,4 +48,4 @@ const CollabCard = ({
     )
 }
 
-export default withRouter(CollabSongCard);
+export default withRouter(CollabCard);

--- a/frontend/components/songs/collab_card.jsx
+++ b/frontend/components/songs/collab_card.jsx
@@ -1,7 +1,8 @@
 import React from "react";
+import { withRouter } from "react-router-dom";
 import ArtistLinkContainer from "../artists/artist_link_container";
 
-const CollabSongCard = ({
+const CollabCard = ({
     song,
     history,
     displayAlbum,
@@ -17,10 +18,10 @@ const CollabSongCard = ({
     } =  song;
 
     const collabArtistNames = collabArtists.map(artist => {
-        return <div className="artist-name" key={`${artist.name}+"collab"+${artist.id}`}><ArtistLinkContainer artist={artist} currentArtist={currentArtist} history={history}/>, </div>
+        return <div className="artist-name" key={`${artist.name}+"collab"+${artist.id}`}><ArtistLinkContainer artist={artist} currentArtist={currentArtist}/>, </div>
     })
 
-    const songArtistName = <ArtistLinkContainer artist={songArtist} currentArtist={currentArtist} history={history}/>
+    const songArtistName = <ArtistLinkContainer artist={songArtist} currentArtist={currentArtist}/>
 
     const handleClick = (e) => {
         e.preventDefault();
@@ -47,4 +48,4 @@ const CollabSongCard = ({
     )
 }
 
-export default CollabSongCard;
+export default withRouter(CollabSongCard);

--- a/frontend/components/songs/collab_song_index.jsx
+++ b/frontend/components/songs/collab_song_index.jsx
@@ -3,7 +3,6 @@ import CollabCard from "./collab_card";
 
 const CollabSongIndex = ({
     songs,
-    history,
     displayAlbum,
     currentArtist,
 }) => {
@@ -19,7 +18,6 @@ const CollabSongIndex = ({
             <CollabCard
                 key={`${song.id}+${song.title}`}
                 song={song}
-                history={history}
                 displayAlbum={displayAlbum}
                 currentArtist={currentArtist}
             />

--- a/frontend/components/songs/song_card.jsx
+++ b/frontend/components/songs/song_card.jsx
@@ -7,7 +7,6 @@ import AlbumLinkContainer from "../albums/album_link_container";
 const SongCard = ({
     source,
     song,
-    history,
     index,
     songCardDropdownState,
     dropdownMenuPointer,
@@ -41,7 +40,6 @@ const SongCard = ({
             <ArtistLinkContainer
                 artist={artist}
                 currentArtist={null}
-                history={history}
             />
             ,&nbsp;
         </div>
@@ -55,7 +53,6 @@ const SongCard = ({
             <ArtistLinkContainer
                 artist={songArtist}
                 currentArtist={null}
-                history={history}
             />
         </div>
     );
@@ -100,7 +97,6 @@ const SongCard = ({
                             name: album,
                         }}
                         currentAlbum={null}
-                        history={history}
                     />
                     : null}
             </div>

--- a/frontend/components/songs/song_card.jsx
+++ b/frontend/components/songs/song_card.jsx
@@ -38,8 +38,6 @@ const SongCard = ({
             key={`${artist.name}+"collab"+${artist.id}`}
         >
             <ArtistLinkContainer
-                artist={artist}
-                currentArtist={null}
             />
             ,&nbsp;
         </div>
@@ -51,8 +49,6 @@ const SongCard = ({
             key={`${songArtist.name}+"track"+${songArtist.id}+${tracknum}`}
         >
             <ArtistLinkContainer
-                artist={songArtist}
-                currentArtist={null}
             />
         </div>
     );

--- a/frontend/components/songs/song_card.jsx
+++ b/frontend/components/songs/song_card.jsx
@@ -96,7 +96,6 @@ const SongCard = ({
                             id: albumId,
                             name: album,
                         }}
-                        currentAlbum={null}
                     />
                     : null}
             </div>

--- a/frontend/components/songs/song_card.jsx
+++ b/frontend/components/songs/song_card.jsx
@@ -37,7 +37,7 @@ const SongCard = ({
             className="artist-name"
             key={`${artist.name}+"collab"+${artist.id}`}
         >
-            <ArtistLinkContainer
+            <ArtistLinkContainer artist={songArtist}
             />
             ,&nbsp;
         </div>
@@ -48,7 +48,7 @@ const SongCard = ({
             className="artist-name"
             key={`${songArtist.name}+"track"+${songArtist.id}+${tracknum}`}
         >
-            <ArtistLinkContainer
+            <ArtistLinkContainer artist={songArtist}
             />
         </div>
     );

--- a/frontend/components/songs/song_card_dropdown.jsx
+++ b/frontend/components/songs/song_card_dropdown.jsx
@@ -10,7 +10,6 @@ const SongCardDropdown = forwardRef(
 		{
 			currentItem,
 			playlists,
-			history,
 			currentUser,
 			selectedSong,
 			songCardDropdownState,
@@ -114,7 +113,6 @@ const SongCardDropdown = forwardRef(
 								</span>
 							</button>
 							<SongCardSubmenu
-								history={history}
 								currentUser={currentUser}
 								selectedSong={selectedSong}
 								songCardDropdownState={songCardDropdownState}
@@ -130,7 +128,6 @@ const SongCardDropdown = forwardRef(
 					) : (
 						<SongCardDropdownItem // Else, create just a button
 							key={`${item.key}+"no-subm"`}
-							history={history}
 							currentItem={currentItem}
 							playlists={playlists}
 							currentUser={currentUser}

--- a/frontend/components/songs/song_card_dropdown.jsx
+++ b/frontend/components/songs/song_card_dropdown.jsx
@@ -23,6 +23,7 @@ const SongCardDropdown = forwardRef(
 			createPlaylist,
 			displayPlaylist,
 			toQueueView,
+			toPlayView,
 		},
 		ref
 	) => {
@@ -145,6 +146,7 @@ const SongCardDropdown = forwardRef(
 							createPlaylist={createPlaylist}
 							displayPlaylist={displayPlaylist}
 							toQueueView={toQueueView}
+							toPlayView={toPlayView}
 						/>
 					);
 				})}

--- a/frontend/components/songs/song_card_dropdown_container.jsx
+++ b/frontend/components/songs/song_card_dropdown_container.jsx
@@ -9,7 +9,9 @@ import {
 	createPlaylist,
 	displayPlaylist,
 } from "../../actions/playlist_actions";
-import { toQueueView } from "../../actions/now_playing_actions";
+import { toQueueView,
+	toPlayView, 
+} from "../../actions/now_playing_actions";
 
 import SongCardDropdown from "./song_card_dropdown";
 
@@ -45,6 +47,7 @@ const mapDispatchToProps = (dispatch) => ({
 	createPlaylist: (playlist) => dispatch(createPlaylist(playlist)),
 	displayPlaylist: (playlistId) => dispatch(displayPlaylist(playlistId)),
 	toQueueView: (objToQueue) => dispatch(toQueueView(objToQueue)),
+	toPlayView: (objToQueue) => dispatch(toPlayView(objToQueue)),
 });
 
 export default connect(mapStateToProps, mapDispatchToProps, null, {

--- a/frontend/components/songs/song_card_dropdown_item.jsx
+++ b/frontend/components/songs/song_card_dropdown_item.jsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { withRouter } from "react-router-dom";
 
 const SongCardDropdownItem = ({
 	history,
@@ -24,19 +25,25 @@ const SongCardDropdownItem = ({
 
 	// Define all song actions
 	const addToQueue = (selectedSongArr) => {
-		objToQueue = {
-			viewSongs: selectedSongArr,
-			sourcedFrom: history.location.pathname,
-		};
-		return toQueueView(objToQueue);
+		if (selectedSongArr?.length > 0) {
+			objToQueue = {
+				viewSongs: selectedSongArr,
+				sourcedFrom: history.location.pathname,
+			};
+			return toQueueView(objToQueue);
+		}
 	};
+
 	const playNow = (selectedSongArr) => {
-		objToQueue = {
-			viewSongs: selectedSongArr,
-			sourcedFrom: history.location.pathname,
-		};
-		return toPlayView(objToQueue);
+		if (selectedSongArr?.length > 0) {
+			objToQueue = {
+				viewSongs: selectedSongArr,
+				sourcedFrom: history.location.pathname,
+			};
+			return toPlayView(objToQueue);
+		}
 	};
+
 	const addToPlaylist = async (selectedSongArr) => {
 		const promises = selectedSongArr.map((song) => {
 			return createNewPlaylisted(song.id, selectedPlaylist.id);
@@ -108,4 +115,4 @@ const SongCardDropdownItem = ({
 	);
 };
 
-export default SongCardDropdownItem;
+export default withRouter(SongCardDropdownItem);

--- a/frontend/components/songs/song_card_dropdown_item.jsx
+++ b/frontend/components/songs/song_card_dropdown_item.jsx
@@ -82,6 +82,7 @@ const SongCardDropdownItem = ({
 			updateSongCardDropdownState({ isOpen: false });
 			return addToQueue(selectedSong);
 		} else if (
+			e.target.innerText === "Play song" ||
 			e.target.innerText === "Play album" ||
 			e.target.innerText === "Play playlist" ||
 			e.target.innerText === "Play artist"

--- a/frontend/components/songs/song_card_dropdown_item.jsx
+++ b/frontend/components/songs/song_card_dropdown_item.jsx
@@ -63,8 +63,10 @@ const SongCardDropdownItem = ({
 			promises = selectedSongArr.map((song) => {
 				return createNewPlaylisted(song.id, playlistId);
 			});
+			Promise.all(promises).then((playlistId) =>
+				history.push(`/playlist/${playlistId}`)
+			);
 		});
-		await Promise.all(promises);
 		fetchPlaylists();
 	};
 

--- a/frontend/components/songs/song_index.jsx
+++ b/frontend/components/songs/song_index.jsx
@@ -10,7 +10,6 @@ const SongIndex = ({
     source,
     songCardDropdownItems,
     currentViewRef,
-    toPlayView,
 }) => {
     // Set local states for SongCardDropdownState and selectedSong
     const [songCardDropdownState, setSongCardDropdownState] = useState({

--- a/frontend/components/songs/song_index.jsx
+++ b/frontend/components/songs/song_index.jsx
@@ -10,6 +10,7 @@ const SongIndex = ({
     source,
     songCardDropdownItems,
     currentViewRef,
+    toPlayView,
 }) => {
     // Set local states for SongCardDropdownState and selectedSong
     const [songCardDropdownState, setSongCardDropdownState] = useState({

--- a/frontend/components/songs/song_index.jsx
+++ b/frontend/components/songs/song_index.jsx
@@ -6,7 +6,6 @@ import SongCardDropdownContainer from "./song_card_dropdown_container";
 const SongIndex = ({
     currentUser,
     songs,
-    history,
     params,
     source,
     songCardDropdownItems,
@@ -93,7 +92,6 @@ const SongIndex = ({
                               key={`${source} + ${song.id} + ${index}`}
                               source={source}
                               song={song}
-                              history={history}
                               index={index}
                               songCardDropdownState={songCardDropdownState}
                               placeSongCardDropdown={placeSongCardDropdown}
@@ -122,7 +120,6 @@ const SongIndex = ({
                 <SongCardDropdownContainer
                     ref={dropdownRef}
                     currentUser={currentUser}
-                    history={history}
                     selectedSong={selectedSong}
                     songCardDropdownState={songCardDropdownState}
                     updateSongCardDropdownState={updateSongCardDropdownState}

--- a/frontend/reducers/artist_index_reducer.js
+++ b/frontend/reducers/artist_index_reducer.js
@@ -1,12 +1,15 @@
 import { RECEIVE_ALL_ARTISTS,
 } from "../actions/artist_actions";
+import { LOGOUT_CURRENT_USER } from "../actions/session_actions";
 
 
-const artistIndexReducer = (artistsState = {}, action) => {
+const artistIndexReducer = (artistsState = [], action) => {
     Object.freeze(artistsState);
     switch (action.type) {
         case RECEIVE_ALL_ARTISTS:
             return action.artists;
+        case LOGOUT_CURRENT_USER:
+            return [];
         default:
             return artistsState;
     }

--- a/frontend/reducers/current_item_reducer.js
+++ b/frontend/reducers/current_item_reducer.js
@@ -8,6 +8,9 @@ import { RECEIVE_CURRENT_ARTIST,
 import { RECEIVE_CURRENT_ALBUM,
 } from "../actions/album_actions";
 
+import { LOGOUT_CURRENT_USER,
+} from "../actions/session_actions";
+
 // used for Playlist#show & Album#show
 const currentItemReducer = (currItemState = {}, action) => {
     Object.freeze(currItemState) // currItemState is an object
@@ -24,6 +27,7 @@ const currentItemReducer = (currItemState = {}, action) => {
             let currAlbum = action.album;
             currAlbum['source'] = "album";
             return currAlbum;
+        case LOGOUT_CURRENT_USER:
         case RESET_CURRENT:
             return {};
         default:

--- a/frontend/reducers/now_playing_reducer.js
+++ b/frontend/reducers/now_playing_reducer.js
@@ -10,6 +10,7 @@ import {
 	PLAY_VIEW,
 } from "../actions/now_playing_actions";
 import { TOGGLE_PLAY } from "../actions/now_playing_actions";
+import { LOGOUT_CURRENT_USER } from "../actions/session_actions";
 
 const nowPlayingReducer = (
 	playState = {
@@ -60,6 +61,11 @@ const nowPlayingReducer = (
 			}
 			newPlayState.isPlaying = true;
 			console.log("NEW QUEUE", newPlayState.queue);
+			return newPlayState;
+		case LOGOUT_CURRENT_USER:
+			newPlayState.isPlaying = false;
+			newPlayState.queue = [];
+			newPlayState.queueSources = [];
 			return newPlayState;
 		default:
 			return playState;

--- a/frontend/reducers/playlist_index_reducer.js
+++ b/frontend/reducers/playlist_index_reducer.js
@@ -1,5 +1,7 @@
 import { RECEIVE_ALL_PLAYLISTS,
 } from "../actions/playlist_actions";
+import { LOGOUT_CURRENT_USER,
+} from "../actions/session_actions";
 
 
 const playlistIndexReducer = (playlistsState = [], action) => {
@@ -7,6 +9,8 @@ const playlistIndexReducer = (playlistsState = [], action) => {
     switch (action.type) {
         case RECEIVE_ALL_PLAYLISTS:
             return action.playlists;
+        case LOGOUT_CURRENT_USER:
+            return [];
         default:
             return playlistsState;
     }

--- a/frontend/reducers/song_index_reducer.js
+++ b/frontend/reducers/song_index_reducer.js
@@ -5,6 +5,8 @@ import { RECEIVE_CURRENT_ARTIST,
 } from "../actions/artist_actions";
 import { RECEIVE_CURRENT_ALBUM,
 } from "../actions/album_actions";
+import { LOGOUT_CURRENT_USER,
+} from "../actions/session_actions";
 
 
 const songIndexReducer = (songsState = [], action) => {
@@ -18,6 +20,7 @@ const songIndexReducer = (songsState = [], action) => {
 				collabSongs: action.collabSongs,
 			};
         case RECEIVE_CURRENT_ALBUM:
+        case LOGOUT_CURRENT_USER:
             return action.songs;
         case RESET_CURRENT:
             return [];

--- a/frontend/reducers/song_index_reducer.js
+++ b/frontend/reducers/song_index_reducer.js
@@ -19,6 +19,8 @@ const songIndexReducer = (songsState = [], action) => {
 			};
         case RECEIVE_CURRENT_ALBUM:
             return action.songs;
+        case RESET_CURRENT:
+            return [];
         default:
             return songsState;
     }

--- a/frontend/reducers/song_index_reducer.js
+++ b/frontend/reducers/song_index_reducer.js
@@ -20,8 +20,8 @@ const songIndexReducer = (songsState = [], action) => {
 				collabSongs: action.collabSongs,
 			};
         case RECEIVE_CURRENT_ALBUM:
-        case LOGOUT_CURRENT_USER:
             return action.songs;
+        case LOGOUT_CURRENT_USER:
         case RESET_CURRENT:
             return [];
         default:


### PR DESCRIPTION
- Uses `withRouter` in order to access `history` more locally across the app
   - Reduces prop drilling, increases code readability, and increases prop separation to decrease page loading time for user
 - AlbumLink/ArtistLink now dynamically uses current path to determine whether to create anchor or not
 - Removes blank whitespace in PlaylistEditModal
 - Adds "Play song" functionality to `SongCardDropdown` from Playlist and Album views
 - Fixes bug where Redux state remained even after user logout
 - Fixes bug where user was encountering error when clicking play on certain views when queue was empty
 - Fixes bug where "Create new playlist" would not display new playlist after its creation
    - This was a "non-iterable" error concerning the variable holding the Promises
 - Fixes bug where `SongCardDropdown` was exiting the viewport

N.B. `withRouter` does also provide the `match` object, which has the key `params` to access the url parameters, but it was not triggering the useEffect on view change, so urlParams is prop drilled manually from AuthRoute instead.

<hr>

TODO:
- [ ] 1) Prevent user from scrolling when PlaylistShow is open.