### PR TITLE
Multiple bug fixes for Play audio functionality

### DIFF
--- a/frontend/actions/now_playing_actions.js
+++ b/frontend/actions/now_playing_actions.js
@@ -4,10 +4,11 @@ export const QUEUE_ARTIST = "QUEUE_ARTIST";
 export const PLAY_ARTIST = "PLAY_ARTIST";
 export const QUEUE_PLAYLIST = "QUEUE_PLAYLIST";
 export const PLAY_PLAYLIST = "PLAY_PLAYLIST";
-export const QUEUE_ALBUM = "QUEUE_ALBUM";
 export const PLAY_ALBUM = "PLAY_ALBUM";
 export const PLAY_VIEW = "PLAY_VIEW";
 export const QUEUE_VIEW = "QUEUE_VIEW";
+export const NEXT_TRACK = "NEXT_TRACK";
+export const PREV_TRACK = "PREV_TRACK";
 
 const togglePlay = () => ({
 	type: TOGGLE_PLAY,
@@ -15,6 +16,14 @@ const togglePlay = () => ({
 
 const pushPlay = () => ({
 	type: PUSH_PLAY,
+});
+
+const nextTrack = () => ({
+	type: NEXT_TRACK,
+});
+
+const prevTrack = () => ({
+	type: PREV_TRACK,
 });
 
 const queueArtist = (objToQueue) => ({
@@ -76,6 +85,10 @@ const playView = (objToQueue) => {
 
 export const toTogglePlay = () => (dispatch) => dispatch(togglePlay());
 
+export const toNextTrack = () => (dispatch) => dispatch(nextTrack());
+
+export const toPrevTrack = () => (dispatch) => dispatch(prevTrack());
+
 export const toQueueArtist = (objToQueue) => (dispatch) => {
 	return dispatch(queueArtist(objToQueue));
 };
@@ -90,10 +103,6 @@ export const toPlayPlaylist = (objToQueue) => (dispatch) => {
 
 export const toQueuePlaylist = (objToQueue) => (dispatch) => {
 	return dispatch(queuePlaylist(objToQueue));
-};
-
-export const toQueueAlbum = (objToQueue) => (dispatch) => {
-	return dispatch(queueAlbum(objToQueue));
 };
 
 export const toPlayAlbum = (objToQueue) => (dispatch) => {

--- a/frontend/actions/now_playing_actions.js
+++ b/frontend/actions/now_playing_actions.js
@@ -9,6 +9,11 @@ export const PLAY_VIEW = "PLAY_VIEW";
 export const QUEUE_VIEW = "QUEUE_VIEW";
 export const NEXT_TRACK = "NEXT_TRACK";
 export const PREV_TRACK = "PREV_TRACK";
+export const CLEAR_QUEUE = "CLEAR_QUEUE";
+
+const clearQueue = () => ({
+	type: CLEAR_QUEUE,
+});
 
 const togglePlay = () => ({
 	type: TOGGLE_PLAY,
@@ -82,6 +87,8 @@ const playView = (objToQueue) => {
 	songs: objToQueue.viewSongs,
 	sourcedFrom: objToQueue.sourcedFrom,
 }};
+
+export const toClearQueue = () => (dispatch) => dispatch(clearQueue());
 
 export const toTogglePlay = () => (dispatch) => dispatch(togglePlay());
 

--- a/frontend/components/albums/album_show_container.js
+++ b/frontend/components/albums/album_show_container.js
@@ -20,7 +20,7 @@ const mapStateToProps = (
 		playlists: playlists,
 		currentUser: currentUser,
 		isPlaying: nowPlaying.isPlaying,
-		currentQueueSource: nowPlaying.queueSources[0],
+		currentQueueSource: nowPlaying.queueSources[nowPlaying.trackIndex],
 		urlParams: params,
 		source: "album",
 		songCardDropdownItems: [

--- a/frontend/components/artists/artist_show_container.js
+++ b/frontend/components/artists/artist_show_container.js
@@ -18,7 +18,7 @@ const mapStateToProps = (state, ownProps) => {
 		allSongs: state.entities.songs.allSongs,
 		collabSongs: state.entities.songs.collabSongs,
 		isPlaying: state.entities.nowPlaying.isPlaying,
-		currentQueueSource: state.entities.nowPlaying.queueSources[0],
+		currentQueueSource: state.entities.nowPlaying.queueSources[state.entities.nowPlaying.trackIndex],
 		currentUser: ownProps.currentUser,
 		urlParams: ownProps.params,
 	};

--- a/frontend/components/player/now_playing_info.jsx
+++ b/frontend/components/player/now_playing_info.jsx
@@ -3,13 +3,8 @@ import AlbumLinkContainer from "../albums/album_link_container";
 import ArtistLinkContainer from "../artists/artist_link_container";
 
 const NowPlayingInfo = ({
-	audioRef,
 	track,
-	trackProgress,
-	history,
-	length, // Refreshes component whenever queue changes
-	isPlaying,
-	updateTrackProgress,
+
 }) => {
 	if (!track) {
 		track = {
@@ -21,9 +16,6 @@ const NowPlayingInfo = ({
 	}
 	const { title, albumId, albumImageUrl, songArtist } = track;
 
-	useEffect(() => {
-		updateTrackProgress(audioRef.current.currentTime);
-	}, [isPlaying]);
 	return (
 		<div className="now-playing">
 			{!!track.title ? (
@@ -39,7 +31,7 @@ const NowPlayingInfo = ({
 							<AlbumLinkContainer
 								album={{
 									id: track.albumId,
-									name: title ,
+									name: title,
 								}}
 							/>
 						</div>

--- a/frontend/components/player/player.jsx
+++ b/frontend/components/player/player.jsx
@@ -26,9 +26,11 @@ const Player = ({
 
 	// Set current track
 	let audioRef = useRef(new Audio()); // creates empty HTMLAudioElement
+	audioRef.current.addEventListener("error", errorCatch, true);
 	let audioSrc;
 
 	useEffect(() => {
+		audioSrc = "";
 		audioSrc = currentTrack?.audioUrl || "";
 		audioRef.current.src = audioSrc;
 		audioRef.current.currentTime = trackProgress;
@@ -41,6 +43,33 @@ const Player = ({
 			audioRef.current.removeEventListener("ended", whenTrackEnds);
 		};
 	}, [currentTrack, trackIndex]); // on first song + in case same song is queued twice
+
+	// Catch audio errors
+	const errorCatch = (e) => {
+		switch (e.target.error.code) {
+			case e.target.error.MEDIA_ERR_ABORTED:
+				console.log("You aborted the video playback.");
+				break;
+			case e.target.error.MEDIA_ERR_NETWORK:
+				console.log(
+					"A network error caused the audio download to fail."
+				);
+				break;
+			case e.target.error.MEDIA_ERR_DECODE:
+				console.log(
+					"The audio playback was aborted due to a corruption problem or because the video used features your browser did not support."
+				);
+				break;
+			case e.target.error.MEDIA_ERR_SRC_NOT_SUPPORTED:
+				console.log(
+					"The video audio not be loaded, either because the server or network failed or because the format is not supported."
+				);
+				break;
+			default:
+				console.log("An unknown error occurred.");
+				break;
+		}
+	};
 
 	// Safely play audio only when it is loaded
 	const tryPlay = () => {
@@ -63,7 +92,7 @@ const Player = ({
 		return () => {
 			audioRef.current.removeEventListener("loadeddata", tryPlay);
 		};
-	}, [isPlaying]);
+	}, [currentTrack, trackIndex, isPlaying]);
 
 	// Behavior when changing tracks
 	const afterFirstRender = useRef(false); // prevent auto-play

--- a/frontend/components/player/player.jsx
+++ b/frontend/components/player/player.jsx
@@ -44,7 +44,7 @@ const Player = ({
 
 	// Safely play audio only when it is loaded
 	const tryPlay = () => {
-		if (audioRef.current.readyState === 4) {
+		if (audioRef.current.readyState === 3) {
 			audioRef.current.play();
 		}
 	};

--- a/frontend/components/player/player_container.js
+++ b/frontend/components/player/player_container.js
@@ -5,21 +5,25 @@ import {
 	toPlayView,
 	toTogglePlay,
 	toPushPlay,
+	toNextTrack,
+	toPrevTrack,
 } from "../../actions/now_playing_actions";
 
 const mapStateToProps = (state, ownProps) => {
 	return {
 		currentUser: state.entities.users[state.session.id],
 		errors: state.entities.errors,
-		tracks: state.entities.nowPlaying.queue,
-		songs: state.entities.songs, // songs of the current view
 		isPlaying: state.entities.nowPlaying.isPlaying,
+		currentTrack: state.entities.nowPlaying.queue[state.entities.nowPlaying.trackIndex],
+		trackIndex: state.entities.nowPlaying.trackIndex,
+		songs: state.entities.songs, // songs of the current view
 		hasQueue: state.entities.nowPlaying.queue.length > 0,
 	};
 };
 
 const mapDispatchToProps = (dispatch) => ({
-	clearPlaylistErrors: () => dispatch(clearPlaylistErrors()),
+	toNextTrack: () => dispatch(toNextTrack()),
+	toPrevTrack: () => dispatch(toPrevTrack()),
 	toPlayView: (objToQueue) => dispatch(toPlayView(objToQueue)),
 	toTogglePlay: () => dispatch(toTogglePlay()),
 	toPushPlay: () => dispatch(toPushPlay()),

--- a/frontend/components/player/player_container.js
+++ b/frontend/components/player/player_container.js
@@ -7,6 +7,7 @@ import {
 	toPushPlay,
 	toNextTrack,
 	toPrevTrack,
+	toClearQueue,
 } from "../../actions/now_playing_actions";
 
 const mapStateToProps = (state, ownProps) => {
@@ -27,6 +28,7 @@ const mapDispatchToProps = (dispatch) => ({
 	toPlayView: (objToQueue) => dispatch(toPlayView(objToQueue)),
 	toTogglePlay: () => dispatch(toTogglePlay()),
 	toPushPlay: () => dispatch(toPushPlay()),
+	toClearQueue: () => dispatch(toClearQueue()),
 });
 
 export default connect(mapStateToProps, mapDispatchToProps)(Player);

--- a/frontend/components/player/playing_controls.jsx
+++ b/frontend/components/player/playing_controls.jsx
@@ -14,10 +14,15 @@ const PlayingControls = ({
 	toPlayView,
 	togglePlay,
 	toPushPlay,
-	toPrevTrack,
-	toNextTrack,
-	toggleShuffle,
+	hitPrev,
+	hitNext,
+	updateTrackProgress,
+	// toggleShuffle,
 }) => {
+	// TODO: Create track progress bar and scrubber
+	// useEffect(() => {
+	// 	updateTrackProgress(audioRef.current.currentTime);
+	// }, [isPlaying]);
 
 	const handleClick = (e) => {
 		e.preventDefault();
@@ -46,7 +51,7 @@ const PlayingControls = ({
 			<BiSkipPrevious
 				className="player__grey-icon"
 				aria-label="Previous"
-				onClick={toPrevTrack}
+				onClick={hitPrev}
 			/>
 			{isPlaying ? (
 				<MdOutlinePauseCircleFilled
@@ -64,7 +69,7 @@ const PlayingControls = ({
 			<BiSkipNext
 				className="player__grey-icon"
 				aria-label="Next"
-				onClick={toNextTrack}
+				onClick={hitNext}
 			/>
 			{/* <BsRepeat // TODO: implement repeat functionality */}
 			<div

--- a/frontend/components/player/playing_controls.jsx
+++ b/frontend/components/player/playing_controls.jsx
@@ -46,7 +46,7 @@ const PlayingControls = ({
 			<div
 				className="player__grey-icon repeat-shuffle-icon"
 				aria-label="Shuffle"
-				onClick={toggleShuffle}
+				// onClick={toggleShuffle}
 			/>
 			<BiSkipPrevious
 				className="player__grey-icon"

--- a/frontend/components/playlists/playlist_show_container.js
+++ b/frontend/components/playlists/playlist_show_container.js
@@ -33,7 +33,7 @@ const mapStateToProps = (
 		playlists: playlists,
 		playlistSongs: songs,
 		isPlaying: nowPlaying.isPlaying,
-		currentQueueSource: nowPlaying.queueSources[0],
+		currentQueueSource: nowPlaying.queueSources[nowPlaying.trackIndex],
 		playlistNavDropdownState: ux.playlistNavDropdown,
 		playlistEditModalState: ux.playlistEditModal,
 		currentUser: currentUser,

--- a/frontend/components/songs/song_card.jsx
+++ b/frontend/components/songs/song_card.jsx
@@ -95,7 +95,7 @@ const SongCard = ({
                     />
                     : null}
             </div>
-            <div className="song-card-liked">&hearts;</div>
+            {/* <div className="song-card-liked">&hearts;</div> */}
             <div className="song-card-duration">
                 {mins}:{secs}
             </div>

--- a/frontend/components/songs/song_card.jsx
+++ b/frontend/components/songs/song_card.jsx
@@ -37,7 +37,7 @@ const SongCard = ({
             className="artist-name"
             key={`${artist.name}+"collab"+${artist.id}`}
         >
-            <ArtistLinkContainer artist={songArtist}
+            <ArtistLinkContainer artist={artist}
             />
             ,&nbsp;
         </div>

--- a/frontend/components/songs/song_index.jsx
+++ b/frontend/components/songs/song_index.jsx
@@ -81,7 +81,7 @@ const SongIndex = ({
                 <div className="song-index-heading-album">
                     {source === "playlist" ? "Album" : null}
                 </div>
-                <div className="song-index-heading-liked">&#128153;</div>
+                {/* <div className="song-index-heading-liked">&#128153;</div> */}
                 <div className="song-index-heading-duration">&#9201;</div>
                 <div className="song-index-heading-menu"></div>
             </div>

--- a/frontend/reducers/now_playing_reducer.js
+++ b/frontend/reducers/now_playing_reducer.js
@@ -78,6 +78,7 @@ const nowPlayingReducer = (
 				});
 			}
 			newPlayState.isPlaying = true;
+			newPlayState.trackIndex = 0;
 			console.log("NEW QUEUE", newPlayState.queue);
 			return newPlayState;
 		case LOGOUT_CURRENT_USER:

--- a/frontend/reducers/now_playing_reducer.js
+++ b/frontend/reducers/now_playing_reducer.js
@@ -8,6 +8,8 @@ import {
 	PLAY_ALBUM,
 	PUSH_PLAY,
 	PLAY_VIEW,
+	NEXT_TRACK,
+	PREV_TRACK,
 } from "../actions/now_playing_actions";
 import { TOGGLE_PLAY } from "../actions/now_playing_actions";
 import { LOGOUT_CURRENT_USER } from "../actions/session_actions";
@@ -15,6 +17,7 @@ import { LOGOUT_CURRENT_USER } from "../actions/session_actions";
 const nowPlayingReducer = (
 	playState = {
 		isPlaying: false,
+		trackIndex: 0,
 		queue: [],
 		queueSources: [],
 	},
@@ -28,8 +31,23 @@ const nowPlayingReducer = (
 	};
 	// Above rectifies issues with shallow copies where nested objs kept the same refs
 	switch (action.type) {
+		case NEXT_TRACK:
+			newPlayState.trackIndex++;
+			if (newPlayState.trackIndex >= newPlayState.queue.length) {
+				newPlayState.trackIndex = 0;
+			}
+			newPlayState.isPlaying = true;
+			return newPlayState;
+		case PREV_TRACK:
+			newPlayState.trackIndex--;
+			if (newPlayState.trackIndex < 0) {
+				newPlayState.trackIndex = newPlayState.queue.length - 1;
+			}
+			newPlayState.isPlaying = true;
+			return newPlayState;
 		case TOGGLE_PLAY:
 			if (newPlayState.queue?.length > 0)
+
 				newPlayState.isPlaying = !newPlayState.isPlaying;
 			return newPlayState;
 		case PUSH_PLAY:

--- a/frontend/reducers/now_playing_reducer.js
+++ b/frontend/reducers/now_playing_reducer.js
@@ -4,12 +4,12 @@ import {
 	QUEUE_PLAYLIST,
 	QUEUE_VIEW,
 	PLAY_PLAYLIST,
-	QUEUE_ALBUM,
 	PLAY_ALBUM,
 	PUSH_PLAY,
 	PLAY_VIEW,
 	NEXT_TRACK,
 	PREV_TRACK,
+	CLEAR_QUEUE,
 } from "../actions/now_playing_actions";
 import { TOGGLE_PLAY } from "../actions/now_playing_actions";
 import { LOGOUT_CURRENT_USER } from "../actions/session_actions";
@@ -34,16 +34,18 @@ const nowPlayingReducer = (
 		case NEXT_TRACK:
 			newPlayState.trackIndex++;
 			if (newPlayState.trackIndex >= newPlayState.queue.length) {
-				newPlayState.trackIndex = 0;
+				newPlayState.trackIndex = null;
+				newPlayState.isPlaying = false;
+				newPlayState.queue = [];
 			}
-			newPlayState.isPlaying = true;
 			return newPlayState;
 		case PREV_TRACK:
 			newPlayState.trackIndex--;
 			if (newPlayState.trackIndex < 0) {
-				newPlayState.trackIndex = newPlayState.queue.length - 1;
+				newPlayState.trackIndex = null;
+				newPlayState.isPlaying = false;
+				newPlayState.queue = [];
 			}
-			newPlayState.isPlaying = true;
 			return newPlayState;
 		case TOGGLE_PLAY:
 			if (newPlayState.queue?.length > 0)
@@ -80,6 +82,11 @@ const nowPlayingReducer = (
 			newPlayState.isPlaying = true;
 			newPlayState.trackIndex = 0;
 			console.log("NEW QUEUE", newPlayState.queue);
+			return newPlayState;
+		case CLEAR_QUEUE:
+			newPlayState.queue = [];
+			newPlayState.queueSources = [];
+			newPlayState.trackIndex = null;
 			return newPlayState;
 		case LOGOUT_CURRENT_USER:
 			newPlayState.isPlaying = false;


### PR DESCRIPTION
- Refactors trackIndex into `nowPlaying` Redux slice of state.
   - Allows user to know current view is the one playing by rendering dynamic UX through a matching index in two parallel arrays in slice of state (`queue` vs `queueSources`); ie. Play button on central menu bar shows pause if current song was queued from the current view
- Fixes various bugs where play would not automatically start when the audio source was switched
- Adds eventListener for when track ends in order to progress automatically to next track in queue
- Refactors `nowPlayingReducer` for a non-repeat mode of playing and track skipping
- Removes unused Liked column from SongIndex