### PR TITLE
Add double-click Play functionality to SongCard

### DIFF
--- a/frontend/actions/now_playing_actions.js
+++ b/frontend/actions/now_playing_actions.js
@@ -11,6 +11,7 @@ export const NEXT_TRACK = "NEXT_TRACK";
 export const PREV_TRACK = "PREV_TRACK";
 export const CLEAR_QUEUE = "CLEAR_QUEUE";
 
+// regular Redux action creators
 const clearQueue = () => ({
 	type: CLEAR_QUEUE,
 });
@@ -88,6 +89,8 @@ const playView = (objToQueue) => {
 	sourcedFrom: objToQueue.sourcedFrom,
 }};
 
+
+// Thunk action creators
 export const toClearQueue = () => (dispatch) => dispatch(clearQueue());
 
 export const toTogglePlay = () => (dispatch) => dispatch(togglePlay());

--- a/frontend/components/albums/album_show.jsx
+++ b/frontend/components/albums/album_show.jsx
@@ -18,6 +18,7 @@ const AlbumShow = ({
 	toPlayAlbum,
 	toPushPlay,
 	toTogglePlay,
+	toPlayView,
 	clearCurrent,
 }) => {
 	useEffect(() => {
@@ -55,6 +56,7 @@ const AlbumShow = ({
 				source={source}
 				songCardDropdownItems={songCardDropdownItems}
 				currentViewRef={albumShowRef}
+				toPlayView={toPlayView}
 			/>
 		</div>
 	);

--- a/frontend/components/albums/album_show_container.js
+++ b/frontend/components/albums/album_show_container.js
@@ -4,6 +4,7 @@ import { displayAlbum } from "../../actions/album_actions";
 import { toPlayAlbum,
 	toPushPlay,
 	toTogglePlay,
+	toPlayView,
 } from "../../actions/now_playing_actions";
 
 import AlbumShow from "./album_show";
@@ -47,6 +48,7 @@ const mapDispatchToProps = (dispatch) => ({
 	toPlayAlbum: (objToQueue) => dispatch(toPlayAlbum(objToQueue)),
 	toPushPlay: () => dispatch(toPushPlay()),
 	toTogglePlay: () => dispatch(toTogglePlay()),
+	toPlayView: (objToQueue) => dispatch(toPlayView(objToQueue)),
 	clearCurrent: () => dispatch(clearCurrent()),
 });
 

--- a/frontend/components/playlists/playlist_show.jsx
+++ b/frontend/components/playlists/playlist_show.jsx
@@ -14,6 +14,7 @@ const PlaylistShow = ({
 	source,
 	songCardDropdownItems,
 	displayPlaylist,
+	toPlayView,
 	clearCurrent,
 	...props
 }) => {
@@ -54,6 +55,7 @@ const PlaylistShow = ({
 				source={source}
 				songCardDropdownItems={songCardDropdownItems}
 				currentViewRef={playlistShowRef}
+				toPlayView={toPlayView}
 			/>
 		</div>
 	) : null;

--- a/frontend/components/playlists/playlist_show_container.js
+++ b/frontend/components/playlists/playlist_show_container.js
@@ -11,6 +11,7 @@ import {
 	toQueuePlaylist,
 	toPlayPlaylist,
 	toPushPlay,
+	toPlayView,
 } from "../../actions/now_playing_actions";
 import {
 	openPlaylistNavDropdown,
@@ -76,6 +77,7 @@ const mapDispatchToProps = (dispatch) => ({
 	toQueuePlaylist: (objToQueue) => dispatch(toQueuePlaylist(objToQueue)),
 	toPlayPlaylist: (objToQueue) => dispatch(toPlayPlaylist(objToQueue)),
 	toPushPlay: () => dispatch(toPushPlay()),
+	toPlayView: (objToQueue) => dispatch(toPlayView(objToQueue)),
 	openPlaylistNavDropdown: () => dispatch(openPlaylistNavDropdown()),
 	closePlaylistNavDropdown: () => dispatch(closePlaylistNavDropdown()),
 	openPlaylistEditModal: () => dispatch(openPlaylistEditModal()),

--- a/frontend/components/songs/song_card.jsx
+++ b/frontend/components/songs/song_card.jsx
@@ -1,112 +1,125 @@
 import React, { useEffect, useState, useRef } from "react";
+import { withRouter } from "react-router-dom";
 
 import { RxDotsHorizontal } from "react-icons/rx";
 import ArtistLinkContainer from "../artists/artist_link_container";
 import AlbumLinkContainer from "../albums/album_link_container";
 
 const SongCard = ({
-    source,
-    song,
-    index,
-    songCardDropdownState,
-    dropdownMenuPointer,
-    placeSongCardDropdown,
-    updateSongCardDropdownState,
-    updateSelectedSong,
-    updateDropdownMenuPointer,
-    dropdownPosition,
+	source,
+	song,
+	index,
+	songCardDropdownState,
+    history,
+	toPlayView,
+	dropdownMenuPointer,
+	placeSongCardDropdown,
+	updateSongCardDropdownState,
+	updateSelectedSong,
+	updateDropdownMenuPointer,
+	dropdownPosition,
 }) => {
-    const {
-        id,
-        title,
-        albumId,
-        album,
-        mins,
-        secs,
-        playlistedId,
-        songArtist,
-        collabArtists,
-        audioUrl,
-    } = song;
+	const {
+		id,
+		title,
+		albumId,
+		album,
+		mins,
+		secs,
+		playlistedId,
+		songArtist,
+		collabArtists,
+		audioUrl,
+	} = song;
 
-    // Set up song info for display
-    let tracknum = source === "album" ? song.tracknum : index + 1;
+	// Set up song info for display
+	let tracknum = source === "album" ? song.tracknum : index + 1;
 
-    const collabArtistNames = collabArtists.map((artist) => (
-        <div
-            className="artist-name"
-            key={`${artist.name}+"collab"+${artist.id}`}
-        >
-            <ArtistLinkContainer artist={artist}
-            />
-            ,&nbsp;
-        </div>
-    ));
+	const collabArtistNames = collabArtists.map((artist) => (
+		<div
+			className="artist-name"
+			key={`${artist.name}+"collab"+${artist.id}`}
+		>
+			<ArtistLinkContainer artist={artist} />
+			,&nbsp;
+		</div>
+	));
 
-    const songArtistName = (
-        <div
-            className="artist-name"
-            key={`${songArtist.name}+"track"+${songArtist.id}+${tracknum}`}
-        >
-            <ArtistLinkContainer artist={songArtist}
-            />
-        </div>
-    );
+	const songArtistName = (
+		<div
+			className="artist-name"
+			key={`${songArtist.name}+"track"+${songArtist.id}+${tracknum}`}
+		>
+			<ArtistLinkContainer artist={songArtist} />
+		</div>
+	);
 
-    const toggleSongCardDropdown = (e) => {
-        e.preventDefault();
-        updateSelectedSong(song);
-        if (!songCardDropdownState.isOpen) {
-            placeSongCardDropdown(e);
-            updateSongCardDropdownState({ isOpen: true });
-        } else if (dropdownMenuPointer === index) {
-            // if user had clicked on the same SongCard, toggle dropdown
-            updateSongCardDropdownState(!songCardDropdownState.isOpen);
-        } else if (
-            songCardDropdownState.isOpen &&
-            dropdownMenuPointer !== index
-        ) {
-            // if user had clicked on a different SongCard, relocate the dropdown
-            updateSongCardDropdownState({ isOpen: false });
-            placeSongCardDropdown(e);
-            updateSongCardDropdownState({ isOpen: true });
-        }
-        updateDropdownMenuPointer(index);
-        updateSelectedSong(song);
-    };
+	const toggleSongCardDropdown = (e) => {
+		e.preventDefault();
+		updateSelectedSong(song);
+		if (!songCardDropdownState.isOpen) {
+			placeSongCardDropdown(e);
+			updateSongCardDropdownState({ isOpen: true });
+		} else if (dropdownMenuPointer === index) {
+			// if user had clicked on the same SongCard, toggle dropdown
+			updateSongCardDropdownState(!songCardDropdownState.isOpen);
+		} else if (
+			songCardDropdownState.isOpen &&
+			dropdownMenuPointer !== index
+		) {
+			// if user had clicked on a different SongCard, relocate the dropdown
+			updateSongCardDropdownState({ isOpen: false });
+			placeSongCardDropdown(e);
+			updateSongCardDropdownState({ isOpen: true });
+		}
+		updateDropdownMenuPointer(index);
+		updateSelectedSong(song);
+	};
 
-    return (
-        <div className="song-card">
-            <div className="song-card-tracknum">{tracknum}</div>
-            <div className="song-card-title-artist-block">
-                <div className="song-card-title">{title}</div>
-                <div className="song-card-artist">
-                    {collabArtistNames}
-                    {songArtistName}
-                </div>
-            </div>
-            <div className="song-card-album">
-                {source === "playlist" ? 
-                    <AlbumLinkContainer
-                        album={{
-                            id: albumId,
-                            name: album,
-                        }}
-                    />
-                    : null}
-            </div>
-            {/* <div className="song-card-liked">&hearts;</div> */}
-            <div className="song-card-duration">
-                {mins}:{secs}
-            </div>
-            <div
-                className="song-card-menu-dots"
-                onClick={toggleSongCardDropdown}
-            >
-                <RxDotsHorizontal />
-            </div>
-        </div>
-    );
+	const objToQueue = {
+		viewSongs: [song], // nowPlaying reducer expects an array of songs
+		sourcedFrom: history.location.pathname,
+	}; // provides linkback to view currently playing
+
+	const handleDoubleClick = (e) => {
+		e.preventDefault();
+		console.log("double clicked song card");
+		console.log(objToQueue);
+		toPlayView(objToQueue);
+	};
+
+	return (
+		<div className="song-card" onDoubleClick={handleDoubleClick}>
+			<div className="song-card-tracknum">{tracknum}</div>
+			<div className="song-card-title-artist-block">
+				<div className="song-card-title">{title}</div>
+				<div className="song-card-artist">
+					{collabArtistNames}
+					{songArtistName}
+				</div>
+			</div>
+			<div className="song-card-album">
+				{source === "playlist" ? (
+					<AlbumLinkContainer
+						album={{
+							id: albumId,
+							name: album,
+						}}
+					/>
+				) : null}
+			</div>
+			{/* <div className="song-card-liked">&hearts;</div> */}
+			<div className="song-card-duration">
+				{mins}:{secs}
+			</div>
+			<div
+				className="song-card-menu-dots"
+				onClick={toggleSongCardDropdown}
+			>
+				<RxDotsHorizontal />
+			</div>
+		</div>
+	);
 };
 
-export default SongCard;
+export default withRouter(SongCard);

--- a/frontend/components/songs/song_index.jsx
+++ b/frontend/components/songs/song_index.jsx
@@ -10,6 +10,7 @@ const SongIndex = ({
     source,
     songCardDropdownItems,
     currentViewRef,
+    toPlayView,
 }) => {
     // Set local states for SongCardDropdownState and selectedSong
     const [songCardDropdownState, setSongCardDropdownState] = useState({
@@ -94,6 +95,7 @@ const SongIndex = ({
                               song={song}
                               index={index}
                               songCardDropdownState={songCardDropdownState}
+                              toPlayView={toPlayView}
                               placeSongCardDropdown={placeSongCardDropdown}
                               updateSongCardDropdownState={
                                   updateSongCardDropdownState


### PR DESCRIPTION
Users can now double-click a SongCard and have it immediately play the song.
- Implemented by giving SongCard access to the `toPlayView` action (through `PlaylistShow` and `AlbumShow` components within which it is nested), the current URL through the `history` prop via the `withRouter` component wrapper, and giving the song as an array to comply with the spread operator in the `nowPlaying` reducer.