### PR TITLE
UX: Smooth over currentView changes and scrolling to top

### DIFF
--- a/frontend/components/albums/album_show.jsx
+++ b/frontend/components/albums/album_show.jsx
@@ -23,13 +23,14 @@ const AlbumShow = ({
 }) => {
 	useEffect(() => {
 		displayAlbum(urlParams.id);
-
-		const rendered = document.getElementById("album-show");
-		rendered ? rendered.scrollTo(0, 0) : null;
-
-		return () => clearCurrent();
 	}, [urlParams]); // Will run whenever urlParams.id changes, otherwise AlbumShow doesn't re-render
 	// Passing this down from currentView bc wrapping withRouter doesn't always trigger useEffect
+
+	useEffect(() => {
+		if (albumShowRef.current) {
+			albumShowRef.current.scrollTo({ top: 0 });
+		}
+	}, [tracks]);
 
 	const albumShowRef = useRef();
 

--- a/frontend/components/albums/album_show.jsx
+++ b/frontend/components/albums/album_show.jsx
@@ -19,7 +19,6 @@ const AlbumShow = ({
 	toPushPlay,
 	toTogglePlay,
 	toPlayView,
-	clearCurrent,
 }) => {
 	useEffect(() => {
 		displayAlbum(urlParams.id);

--- a/frontend/components/albums/album_show_container.js
+++ b/frontend/components/albums/album_show_container.js
@@ -49,7 +49,6 @@ const mapDispatchToProps = (dispatch) => ({
 	toPushPlay: () => dispatch(toPushPlay()),
 	toTogglePlay: () => dispatch(toTogglePlay()),
 	toPlayView: (objToQueue) => dispatch(toPlayView(objToQueue)),
-	clearCurrent: () => dispatch(clearCurrent()),
 });
 
 export default connect(mapStateToProps, mapDispatchToProps)(AlbumShow);

--- a/frontend/components/artists/artist_show.jsx
+++ b/frontend/components/artists/artist_show.jsx
@@ -18,21 +18,20 @@ const ArtistShow = ({
 	toTogglePlay,
 	toPlayArtist,
 	toPushPlay,
-	clearCurrent,
 }) => {
 	useEffect(() => {
-		displayArtist(urlParams.id);
-
-		const rendered = document.getElementById("artist-show");
-		rendered ? rendered.scrollTo(0, 0) : null;
-
-		return () => {
-			clearCurrent();
-		};
+		displayArtist(urlParams.id)
 	}, [urlParams]); // Will run whenever urlParams.id changes, otherwise ArtistShow doesn't re-render
 	// Passing this down from currentView bc wrapping withRouter doesn't always trigger useEffect
 
+	useEffect(() => {
+		if (artistShowRef.current) {
+			artistShowRef.current.scrollTo({ top: 0 });
+		}
+	}, [allSongs]);
+	
 	const artistShowRef = useRef();
+	
 	const artistShow = (
 		<>
 			<div

--- a/frontend/components/artists/artist_show_container.js
+++ b/frontend/components/artists/artist_show_container.js
@@ -30,7 +30,6 @@ const mapDispatchToProps = (dispatch) => ({
 	toTogglePlay: () => dispatch(toTogglePlay()),
 	toPlayArtist: (objToQueue) => dispatch(toPlayArtist(objToQueue)),
 	toPushPlay: () => dispatch(toPushPlay()),
-	clearCurrent: () => dispatch(clearCurrent()),
 });
 
 export default connect(mapStateToProps, mapDispatchToProps)(ArtistShow);

--- a/frontend/components/home/home.jsx
+++ b/frontend/components/home/home.jsx
@@ -1,8 +1,14 @@
-import React from "react";
+import React, {useEffect} from "react";
 
 import ArtistIndexContainer from "../artists/artist_index_container";
 
-const Home = () => {
+const Home = ({
+	clearCurrent,
+}) => {
+
+	useEffect(() => {
+		clearCurrent();
+	}, []);
 	return (
 		<div className="home">
 			<div className="home-header">Your Versify</div>

--- a/frontend/components/home/home_container.jsx
+++ b/frontend/components/home/home_container.jsx
@@ -1,9 +1,12 @@
-import { connect } from "react-redux";
+import { connect } from "react-redux"
+import { clearCurrent } from "../../actions/playlist_actions";
 
 import Home from "./home";
 
 const mapStateToProps = (state, ownProps) => ({});
 
-const mapDispatchToProps = (dispatch) => ({});
+const mapDispatchToProps = (dispatch) => ({
+    clearCurrent: () => dispatch(clearCurrent()),
+});
 
-export default connect(mapStateToProps, null)(Home);
+export default connect(mapStateToProps, mapDispatchToProps)(Home);

--- a/frontend/components/playlists/playlist_show.jsx
+++ b/frontend/components/playlists/playlist_show.jsx
@@ -25,9 +25,20 @@ const PlaylistShow = ({
 	useEffect(() => {
 		displayPlaylist(urlParams.id);
 		// Maybe there's a way to check whether the urlParams.id has changed from the previous and then trigger re-render
-
-		return () => clearCurrent();
 	}, [urlParams]);
+	// Passing this down from currentView bc wrapping withRouter doesn't always trigger useEffect
+
+	useEffect(() => {
+		if (playlistShowRef.current) {
+			playlistShowRef.current.scrollTo({ top: 0 });
+		}
+	}, [playlistSongs]);
+
+	useEffect(() => {
+		if (playlistShowRef.current) {
+			playlistShowRef.current.scrollTo({ top: 0 });
+		}
+	}, [playlistSongs]);
 
 	const playlistShowRef = useRef();
 


### PR DESCRIPTION
PlaylistShow view now scrolls to the top without flashing the background when changing from playlist to playlist.
AlbumShow view now scrolls to the top without flashing the background when changing from album to album.
ArtistShow view now scrolls to the top without flashing the background when changing from artist to artist.

Removed clearCurrent from current view unmounting; added to useEffect upon rendering Home view.

<hr>
TODO:

- [ ] Background still flashes when changing from one view type to another, eg.  from playlist to artist