### PR TITLE
Add queue source navigation to Now Playing Info

### DIFF
--- a/app/assets/stylesheets/05-player.scss
+++ b/app/assets/stylesheets/05-player.scss
@@ -24,6 +24,10 @@
     margin-right: 10px;
 }
 
+.now-playing-art:hover {
+    cursor: pointer;
+}
+
 .now-playing-art img {
     width: 100%;
     height: 100%;
@@ -40,8 +44,14 @@
 }
 
 .now-playing-title {
+    cursor: pointer;
     flex: 0 1 auto;
     width: 200px;
+}
+
+.now-playing-title:hover {
+    text-decoration: underline;
+    cursor: pointer;
 }
 
 .now-playing-buttons{

--- a/frontend/components/albums/album_menu_bar.jsx
+++ b/frontend/components/albums/album_menu_bar.jsx
@@ -21,7 +21,6 @@ const AlbumMenuBar = ({
 	toPushPlay,
 	toTogglePlay,
 }) => {
-	console.log(toPushPlay)
 	// Set local states for AlbumDropdownState
 	const [albumDropdownState, setAlbumDropdownState] = useState({
 		isOpen: false,

--- a/frontend/components/player/now_playing_info.jsx
+++ b/frontend/components/player/now_playing_info.jsx
@@ -4,7 +4,9 @@ import ArtistLinkContainer from "../artists/artist_link_container";
 
 const NowPlayingInfo = ({
 	track,
-
+	trackIndex,
+	queueSources,
+	history,
 }) => {
 	if (!track) {
 		track = {
@@ -16,6 +18,15 @@ const NowPlayingInfo = ({
 	}
 	const { title, albumId, albumImageUrl, songArtist } = track;
 
+	const handleOnClickSongName = () => {
+		let currSource = queueSources[trackIndex];
+		if (history.location.pathname !== currSource) history.push(`${queueSources[trackIndex].sourcedFrom}`);
+	}
+	const handleOnClickAlbumArt = () => {
+		let currSource = queueSources[trackIndex];	
+		if (history.location.pathname!== currSource) history.push(`/album/${albumId}`);
+	}
+
 	return (
 		<div className="now-playing">
 			{!!track.title ? (
@@ -23,17 +34,13 @@ const NowPlayingInfo = ({
 					<div
 						className="now-playing-art"
 						alt={`track artwork for ${title} by ${songArtist.name}`}
+						onClick={handleOnClickAlbumArt}
 					>
 						{albumImageUrl && <img src={albumImageUrl} />}
 					</div>
 					<div className="now-playing-info">
-						<div className="now-playing-title">
-							<AlbumLinkContainer
-								album={{
-									id: track.albumId,
-									name: title,
-								}}
-							/>
+						<div className="now-playing-title" onClick={handleOnClickSongName}>
+							{title}
 						</div>
 						<div className="now-playing-artist">
 							<ArtistLinkContainer

--- a/frontend/components/player/player.jsx
+++ b/frontend/components/player/player.jsx
@@ -7,7 +7,8 @@ const Player = ({
 	isPlaying,
 	currentTrack,
 	trackIndex,
-	songs, // songs of the current view
+	queueSources,
+	songs, // songs of the current view if we initiate playback on a page with songs
 	hasQueue,
 	history,
 	toNextTrack,
@@ -48,7 +49,7 @@ const Player = ({
 	const errorCatch = (e) => {
 		switch (e.target.error.code) {
 			case e.target.error.MEDIA_ERR_ABORTED:
-				console.log("You aborted the video playback.");
+				console.log("You aborted the audio playback.");
 				break;
 			case e.target.error.MEDIA_ERR_NETWORK:
 				console.log(
@@ -57,12 +58,12 @@ const Player = ({
 				break;
 			case e.target.error.MEDIA_ERR_DECODE:
 				console.log(
-					"The audio playback was aborted due to a corruption problem or because the video used features your browser did not support."
+					"The audio playback was aborted due to a corruption problem or because the audio used features your browser did not support."
 				);
 				break;
 			case e.target.error.MEDIA_ERR_SRC_NOT_SUPPORTED:
 				console.log(
-					"The video audio not be loaded, either because the server or network failed or because the format is not supported."
+					"The audio not be loaded, either because the server or network failed or because the format is not supported."
 				);
 				break;
 			default:
@@ -145,9 +146,11 @@ const Player = ({
 
 	return (
 		<div className="player-container">
-			<NowPlayingInfo
+			<NowPlayingInfo // TODO: Clean up what we actually need for NowPlayingInfo
 				audioRef={audioRef}
 				track={currentTrack}
+				trackIndex={trackIndex}
+				queueSources={queueSources}
 				trackProgress={trackProgress}
 				history={history}
 				isPlaying={isPlaying}

--- a/frontend/components/player/player_container.js
+++ b/frontend/components/player/player_container.js
@@ -17,6 +17,7 @@ const mapStateToProps = (state, ownProps) => {
 		isPlaying: state.entities.nowPlaying.isPlaying,
 		currentTrack: state.entities.nowPlaying.queue[state.entities.nowPlaying.trackIndex],
 		trackIndex: state.entities.nowPlaying.trackIndex,
+		queueSources: state.entities.nowPlaying.queueSources,
 		songs: state.entities.songs, // songs of the current view
 		hasQueue: state.entities.nowPlaying.queue.length > 0,
 	};

--- a/frontend/components/playlists/playlist_nav_dropdown.jsx
+++ b/frontend/components/playlists/playlist_nav_dropdown.jsx
@@ -61,8 +61,7 @@ const PlaylistNavDropdown = ({
 				playNow(objToQueue);
 				return closePlaylistNavDropdown();
 			case "Edit details":
-				openPlaylistEditModal();
-				return console.log("OPEN EDIT MODAL");
+				return openPlaylistEditModal();
 			case "Delete":
 				destroyPlaylist(currentPlaylist.id);
 				return history.push("/home");

--- a/frontend/components/session/session_form.jsx
+++ b/frontend/components/session/session_form.jsx
@@ -42,7 +42,6 @@ class SessionForm extends React.Component {
             username: 'userdemo',
             password: 'userdemo',
         }
-        console.log(formUser)
         this.props.createSession(formUser)
             .then ( () => this.props.history.push('/home'));
         ;

--- a/frontend/components/sidebar/sidebar_nav_button.jsx
+++ b/frontend/components/sidebar/sidebar_nav_button.jsx
@@ -4,8 +4,6 @@ const SidebarNavButton = (props) => {
     // eg. Home button, Search button
     const { text, icon, url, history } = props;
 
-    console.log("SidebarNAVButtonPROPS", props);
-
     const clickToNavigate = (e) => {
         e.preventDefault();
         history.push(`/${url}`);

--- a/frontend/components/songs/song_card.jsx
+++ b/frontend/components/songs/song_card.jsx
@@ -83,8 +83,6 @@ const SongCard = ({
 
 	const handleDoubleClick = (e) => {
 		e.preventDefault();
-		console.log("double clicked song card");
-		console.log(objToQueue);
 		toPlayView(objToQueue);
 	};
 


### PR DESCRIPTION
Users can now click the song title in the track info of the player, and they will be navigated to the view (album or playlist view) that the track was originally queued/played from.

Users can also click the album art and be navigated to the track's album view.